### PR TITLE
feat: redesign community page with Soomgo design system (#59)

### DIFF
--- a/components/community/CategoryTabs.tsx
+++ b/components/community/CategoryTabs.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { POST_CATEGORIES } from '@/lib/types/community'
+import type { PostCategory } from '@/lib/types/community'
+import { theme } from '@/lib/theme'
+
+interface CategoryTabsProps {
+  selectedCategory?: PostCategory
+  onCategoryChange: (category?: PostCategory) => void
+  className?: string
+}
+
+export function CategoryTabs({ selectedCategory, onCategoryChange, className = '' }: CategoryTabsProps) {
+  const categories = [
+    { key: undefined, label: '전체' },
+    ...Object.entries(POST_CATEGORIES).map(([key, label]) => ({
+      key: key as PostCategory,
+      label
+    }))
+  ]
+
+  return (
+    <div className={`flex flex-wrap gap-2 ${className}`}>
+      {categories.map(({ key, label }) => {
+        const isSelected = selectedCategory === key
+
+        return (
+          <button
+            key={key || 'all'}
+            onClick={() => onCategoryChange(key)}
+            className="px-4 py-2 rounded-full text-sm font-medium transition-colors duration-200 whitespace-nowrap"
+            style={{
+              backgroundColor: isSelected
+                ? theme.colors.primary.main
+                : theme.colors.secondary.light,
+              color: isSelected
+                ? theme.colors.white
+                : theme.colors.primary.main,
+              border: 'none',
+              cursor: 'pointer'
+            }}
+            onMouseEnter={(e) => {
+              if (!isSelected) {
+                e.currentTarget.style.backgroundColor = theme.colors.secondary.medium
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!isSelected) {
+                e.currentTarget.style.backgroundColor = theme.colors.secondary.light
+              }
+            }}
+          >
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/community/PostCard.tsx
+++ b/components/community/PostCard.tsx
@@ -8,6 +8,7 @@ import { POST_CATEGORIES, POST_STATUS_LABELS } from '@/lib/types/community'
 import type { Post } from '@/lib/types/community'
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
+import { theme } from '@/lib/theme'
 
 interface PostCardProps {
   post: Post
@@ -71,8 +72,11 @@ export function PostCard({ post, currentUserId, showActions = false, isPinned = 
   const isAuthor = currentUserId === post.metadata.authorId
 
   return (
-    <Card className={`hover:shadow-md transition-shadow ${isPinned ? 'border-blue-200 bg-blue-50' : ''}`}>
-      <CardContent className="p-4">
+    <Card
+      className={`transition-all duration-200 hover:shadow-lg hover:-translate-y-1 ${isPinned ? 'border-blue-200 bg-blue-50' : ''}`}
+      style={theme.components.cards.default}
+    >
+      <CardContent style={{ padding: theme.components.cards.default.padding }}>
         <div className="flex items-start space-x-3">
           {/* 카테고리 아이콘 */}
           <div className="text-2xl flex-shrink-0">
@@ -128,13 +132,15 @@ export function PostCard({ post, currentUserId, showActions = false, isPinned = 
             </div>
 
             {/* 작성자와 미리보기 */}
-            <p className="text-sm text-gray-600 mb-2">
-              <span className="font-medium">{post.metadata.authorName}</span>
+            <p className="mb-2" style={{ fontSize: '14px', color: theme.colors.neutral.medium }}>
+              <span className="font-medium" style={{ color: theme.colors.neutral.darkest }}>
+                {post.metadata.authorName}
+              </span>
               {post.content && (
                 <>
                   {' | '}
                   <span className="line-clamp-1">
-                    "{post.content.slice(0, 50)}{post.content.length > 50 ? '...' : ''}"
+                    &ldquo;{post.content.slice(0, 50)}{post.content.length > 50 ? '...' : ''}&rdquo;
                   </span>
                 </>
               )}
@@ -142,17 +148,26 @@ export function PostCard({ post, currentUserId, showActions = false, isPinned = 
 
             {/* 통계 및 첨부파일 */}
             <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-4 text-xs text-gray-500">
+              <div className="flex items-center space-x-4 text-xs" style={{ color: theme.colors.neutral.medium }}>
                 <span className="flex items-center">
-                  <Heart className="h-3 w-3 mr-1" />
+                  <Heart
+                    className="h-3 w-3 mr-1"
+                    style={{ color: theme.colors.primary.main }}
+                  />
                   {post.stats.likes}
                 </span>
                 <span className="flex items-center">
-                  <MessageCircle className="h-3 w-3 mr-1" />
+                  <MessageCircle
+                    className="h-3 w-3 mr-1"
+                    style={{ color: theme.colors.primary.main }}
+                  />
                   {post.stats.comments}
                 </span>
                 <span className="flex items-center">
-                  <Eye className="h-3 w-3 mr-1" />
+                  <Eye
+                    className="h-3 w-3 mr-1"
+                    style={{ color: theme.colors.primary.main }}
+                  />
                   {post.stats.views}
                 </span>
               </div>

--- a/components/community/PostList.tsx
+++ b/components/community/PostList.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { PostCard } from './PostCard'
+import { CategoryTabs } from './CategoryTabs'
 import { Button, Badge } from '@/components/core'
 import { Search, Filter } from 'lucide-react'
 import { getPostsAction } from '@/lib/actions/posts'
@@ -103,33 +104,16 @@ export function PostList({ initialPosts, currentUserId, showActions = false }: P
           </Button>
         </div>
 
+        {/* 카테고리 탭 */}
+        <CategoryTabs
+          selectedCategory={Array.isArray(filters.category) ? filters.category[0] : filters.category}
+          onCategoryChange={handleCategoryFilter}
+          className="mb-4"
+        />
+
         {/* 필터 옵션 */}
         {showFilters && (
           <div className="bg-gray-50 p-4 rounded-lg space-y-4">
-            {/* 카테고리 필터 */}
-            <div>
-              <label className="block text-sm font-medium mb-2">카테고리</label>
-              <div className="flex flex-wrap gap-2">
-                <Badge
-                  variant={filters.category === undefined ? 'default' : 'outline'}
-                  className="cursor-pointer"
-                  onClick={() => handleCategoryFilter(undefined)}
-                >
-                  전체
-                </Badge>
-                {Object.entries(POST_CATEGORIES).map(([key, label]) => (
-                  <Badge
-                    key={key}
-                    variant={filters.category === key ? 'default' : 'outline'}
-                    className="cursor-pointer"
-                    onClick={() => handleCategoryFilter(key as PostCategory)}
-                  >
-                    {label}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-
             {/* 정렬 옵션 */}
             <div>
               <label className="block text-sm font-medium mb-2">정렬</label>


### PR DESCRIPTION
## Summary
Redesigns the community page category tabs and post cards according to the Soomgo design system requirements from issue #59.

## Changes Made

### 🎨 CategoryTabs Component (New)
- Created new `CategoryTabs` component with proper Soomgo color scheme
- **Selected tab**: #693BF2 background with white text  
- **Unselected tab**: #F1EEFF background with #693BF2 text
- Responsive design using `flex flex-wrap` for mobile compatibility
- Hover effects for better UX

### 🎯 PostCard Component Updates
- Applied Soomgo card styling from theme system
- **Author text**: Updated to 14px as specified
- **Icons**: Like/comment/eye icons now use #693BF2 color (primary color)
- **Card styling**: Uses `theme.components.cards.default` with hover effects
- **ESLint fix**: Replaced unescaped quotes with HTML entities

### 🔧 PostList Integration
- Replaced Badge-based category filtering with CategoryTabs
- CategoryTabs now appears above the filter options as primary navigation
- Maintained all existing filtering functionality
- Fixed TypeScript issues with category array/single handling

### ✅ Quality Assurance
- **Write button**: Verified using primary button styling (already correct)
- **Responsive design**: Tested with dev server, CategoryTabs wraps properly on mobile
- **Build verification**: Successfully compiles with `npm run build`
- **TypeScript**: Fixed all type errors related to changes
- **ESLint**: Fixed unescaped quote issues

## Test Plan
- [x] Development server runs successfully
- [x] CategoryTabs display with correct colors
- [x] PostCard icons show in #693BF2 color  
- [x] Author text displays at 14px
- [x] Responsive design works on mobile
- [x] All filtering functionality preserved
- [x] Build compiles successfully
- [x] TypeScript errors resolved

## Screenshots
The community page now features:
- Tab-based category navigation with Soomgo colors
- Enhanced post cards with proper styling and icon colors
- Consistent design system integration

Fixes #59

🤖 Generated with [Claude Code](https://claude.ai/code)