### PR TITLE
feat: Implement Step1AccountInfo with Google social login

### DIFF
--- a/__tests__/app/signup/components/Step1AccountInfo.test.tsx
+++ b/__tests__/app/signup/components/Step1AccountInfo.test.tsx
@@ -1,0 +1,604 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Step1AccountInfo, { Step1AccountInfoProps } from '@/app/signup/components/Step1AccountInfo';
+import { signInWithGoogle } from '@/lib/auth/providers';
+import type { User } from '@/lib/types/auth';
+
+// Mock auth providers
+jest.mock('@/lib/auth/providers', () => ({
+  signInWithGoogle: jest.fn(),
+}));
+
+// Mock SignupButton component
+jest.mock('@/app/signup/components/SignupButton', () => ({
+  __esModule: true,
+  default: ({ children, onClick, loading, variant, ...props }: any) => (
+    <button
+      onClick={onClick}
+      disabled={loading}
+      data-testid="signup-button"
+      data-variant={variant}
+      data-loading={loading}
+      {...props}
+    >
+      {loading ? '로그인 중...' : children}
+    </button>
+  ),
+}));
+
+describe('Step1AccountInfo', () => {
+  // Mock functions
+  const mockOnNext = jest.fn();
+  const mockOnUpdateAccountData = jest.fn();
+  const mockSignInWithGoogle = signInWithGoogle as jest.MockedFunction<typeof signInWithGoogle>;
+
+  // Default props
+  const defaultProps: Step1AccountInfoProps = {
+    onNext: mockOnNext,
+    onUpdateAccountData: mockOnUpdateAccountData,
+  };
+
+  // Mock user data
+  const mockUser: User = {
+    id: 'test-user-123',
+    email: 'test@example.com',
+    displayName: 'Test User',
+    photoURL: 'https://example.com/photo.jpg',
+    provider: 'google',
+    createdAt: new Date(),
+    lastLoginAt: new Date(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('초기 렌더링', () => {
+    it('should render the component with all UI elements', () => {
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      // Check header elements
+      expect(screen.getByText('소셜 계정으로 시작하기')).toBeInTheDocument();
+      expect(screen.getByText(/Google 계정으로 간편하게 가입하고/)).toBeInTheDocument();
+      expect(screen.getByText(/스윙댄스 커뮤니티에 참여하세요/)).toBeInTheDocument();
+
+      // Check button
+      const button = screen.getByTestId('signup-button');
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveTextContent('Google로 계속하기');
+      expect(button).toHaveAttribute('aria-label', 'Google로 계속하기');
+      expect(button).toHaveAttribute('data-variant', 'social-google');
+
+      // Check info section
+      expect(screen.getByText('안전한 소셜 로그인')).toBeInTheDocument();
+      expect(screen.getByText('빠른 회원가입')).toBeInTheDocument();
+      expect(screen.getByText('간편한 정보 입력')).toBeInTheDocument();
+
+      // Check divider text
+      expect(screen.getByText('안전하고 빠른 가입')).toBeInTheDocument();
+    });
+
+    it('should not show error message initially', () => {
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const errorAlert = screen.queryByRole('alert');
+      expect(errorAlert).not.toBeInTheDocument();
+    });
+
+    it('should render button in enabled state initially', () => {
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      expect(button).not.toBeDisabled();
+      expect(button).toHaveAttribute('data-loading', 'false');
+    });
+  });
+
+  describe('Google 로그인 성공', () => {
+    it('should call signInWithGoogle when button is clicked', async () => {
+      mockSignInWithGoogle.mockResolvedValueOnce(mockUser);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      expect(mockSignInWithGoogle).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update account data with correct user information', async () => {
+      mockSignInWithGoogle.mockResolvedValueOnce(mockUser);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockOnUpdateAccountData).toHaveBeenCalledWith({
+          provider: 'google',
+          uid: 'test-user-123',
+          email: 'test@example.com',
+          displayName: 'Test User',
+          photoURL: 'https://example.com/photo.jpg',
+        });
+      });
+    });
+
+    it('should call onNext after successful login', async () => {
+      mockSignInWithGoogle.mockResolvedValueOnce(mockUser);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockOnNext).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should handle user with missing optional fields', async () => {
+      const userWithoutOptionals: User = {
+        ...mockUser,
+        email: null,
+        displayName: null,
+        photoURL: null,
+      };
+
+      mockSignInWithGoogle.mockResolvedValueOnce(userWithoutOptionals);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockOnUpdateAccountData).toHaveBeenCalledWith({
+          provider: 'google',
+          uid: 'test-user-123',
+          email: '',
+          displayName: '',
+          photoURL: '',
+        });
+      });
+    });
+
+    it('should show loading state during login', async () => {
+      mockSignInWithGoogle.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve(mockUser), 100))
+      );
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      // Check loading state
+      expect(button).toHaveAttribute('data-loading', 'true');
+      expect(button).toBeDisabled();
+      expect(button).toHaveTextContent('로그인 중...');
+
+      // Wait for completion
+      await waitFor(() => {
+        expect(mockOnNext).toHaveBeenCalled();
+      });
+
+      // Loading should be cleared
+      expect(button).toHaveAttribute('data-loading', 'false');
+    });
+  });
+
+  describe('Google 로그인 실패', () => {
+    it('should show error message when popup is blocked', async () => {
+      const error: any = new Error('Popup blocked');
+      error.code = 'auth/popup-blocked';
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        const errorAlert = screen.getByRole('alert');
+        expect(errorAlert).toBeInTheDocument();
+        expect(errorAlert.textContent).toContain('팝업이 차단되었습니다. 브라우저 설정에서 팝업을 허용해주세요.');
+      });
+    });
+
+    it('should show error message when user cancels login', async () => {
+      const error: any = new Error('User cancelled');
+      error.code = 'auth/popup-closed-by-user';
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        const errorAlert = screen.getByRole('alert');
+        expect(errorAlert.textContent).toContain('로그인이 취소되었습니다.');
+      });
+    });
+
+    it('should show error message for network errors', async () => {
+      const error: any = new Error('Network error');
+      error.code = 'auth/network-request-failed';
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        const errorAlert = screen.getByRole('alert');
+        expect(errorAlert.textContent).toContain('네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.');
+      });
+    });
+
+    it('should show generic error message for unknown errors', async () => {
+      const error: any = { code: 'auth/unknown' }; // Error without message
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        const errorAlert = screen.getByRole('alert');
+        expect(errorAlert.textContent).toContain('로그인에 실패했습니다. 다시 시도해주세요.');
+      });
+    });
+
+    it('should show error message from error.message if available', async () => {
+      const error = new Error('Custom error message');
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        const errorAlert = screen.getByRole('alert');
+        expect(errorAlert.textContent).toContain('Custom error message');
+      });
+    });
+
+    it('should not call onNext when login fails', async () => {
+      const error = new Error('Login failed');
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+
+      expect(mockOnNext).not.toHaveBeenCalled();
+    });
+
+    it('should clear loading state after error', async () => {
+      const error = new Error('Login failed');
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+
+      expect(button).toHaveAttribute('data-loading', 'false');
+      expect(button).not.toBeDisabled();
+    });
+
+    it('should log error to console', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const error = new Error('Test error');
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalledWith('Google login failed:', error);
+      });
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('에러 메시지 표시', () => {
+    it('should display error with warning icon', async () => {
+      const error = new Error('Test error');
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        const errorAlert = screen.getByRole('alert');
+        expect(errorAlert).toBeInTheDocument();
+        expect(errorAlert).toHaveTextContent('⚠️');
+        expect(errorAlert).toHaveTextContent('Test error');
+      });
+    });
+
+    it('should clear error when retrying login', async () => {
+      const error = new Error('First error');
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+
+      // First attempt - error
+      await userEvent.click(button);
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      });
+
+      // Second attempt - success
+      mockSignInWithGoogle.mockResolvedValueOnce(mockUser);
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should replace old error with new error on subsequent failures', async () => {
+      const error1 = new Error('First error');
+      const error2 = new Error('Second error');
+
+      mockSignInWithGoogle.mockRejectedValueOnce(error1);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+
+      // First attempt
+      await userEvent.click(button);
+      await waitFor(() => {
+        expect(screen.getByText('First error')).toBeInTheDocument();
+      });
+
+      // Second attempt
+      mockSignInWithGoogle.mockRejectedValueOnce(error2);
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByText('Second error')).toBeInTheDocument();
+        expect(screen.queryByText('First error')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('로딩 상태', () => {
+    it('should disable button during loading', async () => {
+      mockSignInWithGoogle.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve(mockUser), 100))
+      );
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      expect(button).toBeDisabled();
+
+      await waitFor(() => {
+        expect(mockOnNext).toHaveBeenCalled();
+      });
+    });
+
+    it('should show loading text during login', async () => {
+      mockSignInWithGoogle.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve(mockUser), 100))
+      );
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      expect(button).toHaveTextContent('Google로 계속하기');
+
+      await userEvent.click(button);
+
+      expect(button).toHaveTextContent('로그인 중...');
+
+      await waitFor(() => {
+        expect(mockOnNext).toHaveBeenCalled();
+      });
+    });
+
+    it('should prevent multiple simultaneous login attempts', async () => {
+      mockSignInWithGoogle.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve(mockUser), 100))
+      );
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+
+      // Click multiple times
+      await userEvent.click(button);
+      await userEvent.click(button);
+      await userEvent.click(button);
+
+      // Should only be called once because button is disabled after first click
+      await waitFor(() => {
+        expect(mockOnNext).toHaveBeenCalled();
+      });
+
+      expect(mockSignInWithGoogle).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('접근성', () => {
+    it('should have proper ARIA labels on button', () => {
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      expect(button).toHaveAttribute('aria-label', 'Google로 계속하기');
+    });
+
+    it('should use role="alert" for error messages', async () => {
+      const error = new Error('Test error');
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        const errorAlert = screen.getByRole('alert');
+        expect(errorAlert).toBeInTheDocument();
+      });
+    });
+
+    it('should be keyboard accessible', async () => {
+      mockSignInWithGoogle.mockResolvedValueOnce(mockUser);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+
+      // Tab to button and press Enter
+      button.focus();
+      expect(button).toHaveFocus();
+
+      fireEvent.keyDown(button, { key: 'Enter', code: 'Enter' });
+      await userEvent.click(button); // Simulate the click that would happen with Enter
+
+      await waitFor(() => {
+        expect(mockSignInWithGoogle).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('스타일링', () => {
+    it('should render Glassmorphism card with correct classes', () => {
+      const { container } = render(<Step1AccountInfo {...defaultProps} />);
+
+      const card = container.querySelector('.step1-card');
+      expect(card).toBeInTheDocument();
+
+      const cardContainer = container.querySelector('.step1-container');
+      expect(cardContainer).toBeInTheDocument();
+    });
+
+    it('should render with proper layout structure', () => {
+      const { container } = render(<Step1AccountInfo {...defaultProps} />);
+
+      expect(container.querySelector('.step1-header')).toBeInTheDocument();
+      expect(container.querySelector('.step1-content')).toBeInTheDocument();
+      expect(container.querySelector('.info-section')).toBeInTheDocument();
+    });
+
+    it('should display info items with icons and text', () => {
+      const { container } = render(<Step1AccountInfo {...defaultProps} />);
+
+      const infoItems = container.querySelectorAll('.info-item');
+      expect(infoItems).toHaveLength(3);
+
+      const icons = container.querySelectorAll('.info-icon');
+      expect(icons).toHaveLength(3);
+      expect(icons[0]).toHaveTextContent('🔒');
+      expect(icons[1]).toHaveTextContent('⚡');
+      expect(icons[2]).toHaveTextContent('✨');
+    });
+
+    it('should have responsive design classes', () => {
+      const { container } = render(<Step1AccountInfo {...defaultProps} />);
+
+      // Check that style tag exists (indicates styled-jsx is working)
+      const styles = container.querySelector('style');
+      expect(styles).toBeInTheDocument();
+    });
+  });
+
+  describe('컴포넌트 displayName', () => {
+    it('should have proper displayName for debugging', () => {
+      expect(Step1AccountInfo.displayName).toBe('Step1AccountInfo');
+    });
+  });
+
+  describe('통합 시나리오', () => {
+    it('should complete full successful login flow', async () => {
+      mockSignInWithGoogle.mockResolvedValueOnce(mockUser);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      // Initial state
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      const button = screen.getByTestId('signup-button');
+      expect(button).not.toBeDisabled();
+
+      // Click login
+      await userEvent.click(button);
+
+      // Wait for completion
+      await waitFor(() => {
+        expect(mockSignInWithGoogle).toHaveBeenCalled();
+        expect(mockOnUpdateAccountData).toHaveBeenCalledWith({
+          provider: 'google',
+          uid: mockUser.id,
+          email: mockUser.email,
+          displayName: mockUser.displayName,
+          photoURL: mockUser.photoURL,
+        });
+        expect(mockOnNext).toHaveBeenCalled();
+      });
+
+      // No error shown
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('should handle retry after error', async () => {
+      const error: any = new Error('Network error');
+      error.code = 'auth/network-request-failed';
+
+      mockSignInWithGoogle.mockRejectedValueOnce(error);
+
+      render(<Step1AccountInfo {...defaultProps} />);
+
+      const button = screen.getByTestId('signup-button');
+
+      // First attempt fails
+      await userEvent.click(button);
+      await waitFor(() => {
+        const errorAlert = screen.getByRole('alert');
+        expect(errorAlert.textContent).toContain('네트워크 오류가 발생했습니다');
+      });
+
+      // Second attempt succeeds
+      mockSignInWithGoogle.mockResolvedValueOnce(mockUser);
+      await userEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockOnNext).toHaveBeenCalled();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/app/signup/components/SignupButton.tsx
+++ b/app/signup/components/SignupButton.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import React from 'react';
+
+export interface SignupButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant: 'primary' | 'social-google';
+  loading?: boolean;
+  children: React.ReactNode;
+}
+
+const SignupButton = React.memo<SignupButtonProps>(
+  ({ variant, loading = false, disabled, children, className = '', ...props }) => {
+    const getVariantStyles = () => {
+      const baseStyles = `
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        width: 100%;
+        height: 56px;
+        border: none;
+        border-radius: 14px;
+        font-size: 16px;
+        font-weight: 700;
+        cursor: ${disabled || loading ? 'not-allowed' : 'pointer'};
+        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        position: relative;
+        overflow: hidden;
+        opacity: ${disabled || loading ? 0.6 : 1};
+      `;
+
+      const variantMap = {
+        'primary': `
+          ${baseStyles}
+          background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+          color: white;
+          box-shadow: 0 4px 16px rgba(102, 126, 234, 0.3);
+        `,
+        'social-google': `
+          ${baseStyles}
+          background: linear-gradient(135deg, #4285f4 0%, #357ae8 100%);
+          color: white;
+          box-shadow: 0 4px 16px rgba(66, 133, 244, 0.3);
+        `,
+      };
+
+      return variantMap[variant];
+    };
+
+    const getHoverStyles = () => {
+      const hoverMap = {
+        'primary': 'box-shadow: 0 8px 24px rgba(102, 126, 234, 0.5);',
+        'social-google': 'box-shadow: 0 8px 24px rgba(66, 133, 244, 0.5);',
+      };
+
+      return hoverMap[variant];
+    };
+
+    const getIcon = () => {
+      if (loading) {
+        return <span className="spinner">⏳</span>;
+      }
+
+      const iconMap = {
+        'primary': null,
+        'social-google': '🔵',
+      };
+
+      const icon = iconMap[variant];
+      return icon ? <span style={{ fontSize: '24px' }}>{icon}</span> : null;
+    };
+
+    return (
+      <>
+        <button
+          className={`signup-button ${className}`}
+          disabled={disabled || loading}
+          aria-busy={loading}
+          aria-label={loading ? '로딩 중...' : props['aria-label']}
+          {...props}
+        >
+          {getIcon()}
+          <span>{loading ? '로딩 중...' : children}</span>
+        </button>
+
+        <style jsx>{`
+          .signup-button {
+            ${getVariantStyles()}
+          }
+
+          .signup-button::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: -100%;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+            transition: left 0.5s;
+          }
+
+          .signup-button:hover::before {
+            left: 100%;
+          }
+
+          .signup-button:not(:disabled):hover {
+            transform: translateY(-3px) scale(1.02);
+            ${getHoverStyles()}
+          }
+
+          .signup-button:not(:disabled):active {
+            transform: translateY(-1px) scale(0.98);
+          }
+
+          .signup-button:focus-visible {
+            outline: none;
+            ring: 2px solid #693BF2;
+            ring-offset: 2px;
+          }
+
+          .spinner {
+            display: inline-block;
+            animation: spin 1s linear infinite;
+          }
+
+          @keyframes spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+          }
+
+          @media (max-width: 768px) {
+            .signup-button {
+              height: 52px;
+              font-size: 15px;
+            }
+          }
+        `}</style>
+      </>
+    );
+  }
+);
+
+SignupButton.displayName = 'SignupButton';
+
+export default SignupButton;

--- a/app/signup/components/Step1AccountInfo.tsx
+++ b/app/signup/components/Step1AccountInfo.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import React, { useState } from 'react';
+import SignupButton from './SignupButton';
+import { signInWithGoogle } from '@/lib/auth/providers';
+import type { SignupState } from '@/lib/types/signup';
+
+export interface Step1AccountInfoProps {
+  onNext: () => void;
+  onUpdateAccountData: (data: Partial<SignupState['accountData']>) => void;
+}
+
+const Step1AccountInfo: React.FC<Step1AccountInfoProps> = ({ onNext, onUpdateAccountData }) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+
+  const handleGoogleLogin = async () => {
+    try {
+      setLoading(true);
+      setError('');
+
+      // Call Firebase Google authentication
+      const user = await signInWithGoogle();
+
+      // Update account data in SignupWizard state
+      onUpdateAccountData({
+        provider: 'google',
+        uid: user.id,
+        email: user.email || '',
+        displayName: user.displayName || '',
+        photoURL: user.photoURL || '',
+      });
+
+      // Auto-advance to next step
+      onNext();
+    } catch (err: any) {
+      console.error('Google login failed:', err);
+
+      // Handle specific error codes first, then custom messages
+      if (err.code === 'auth/popup-blocked') {
+        setError('팝업이 차단되었습니다. 브라우저 설정에서 팝업을 허용해주세요.');
+      } else if (err.code === 'auth/popup-closed-by-user') {
+        setError('로그인이 취소되었습니다.');
+      } else if (err.code === 'auth/network-request-failed') {
+        setError('네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.');
+      } else if (err.message && typeof err.message === 'string') {
+        setError(err.message);
+      } else {
+        setError('로그인에 실패했습니다. 다시 시도해주세요.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="step1-container">
+        <div className="step1-card">
+          <div className="step1-header">
+            <h2 className="step1-title">소셜 계정으로 시작하기</h2>
+            <p className="step1-description">
+              Google 계정으로 간편하게 가입하고<br />
+              스윙댄스 커뮤니티에 참여하세요
+            </p>
+          </div>
+
+          <div className="step1-content">
+            {error && (
+              <div className="error-message" role="alert">
+                <span className="error-icon">⚠️</span>
+                <span className="error-text">{error}</span>
+              </div>
+            )}
+
+            <SignupButton
+              variant="social-google"
+              loading={loading}
+              onClick={handleGoogleLogin}
+              aria-label="Google로 계속하기"
+            >
+              Google로 계속하기
+            </SignupButton>
+
+            <div className="divider">
+              <span className="divider-text">안전하고 빠른 가입</span>
+            </div>
+
+            <div className="info-section">
+              <div className="info-item">
+                <span className="info-icon">🔒</span>
+                <span className="info-text">안전한 소셜 로그인</span>
+              </div>
+              <div className="info-item">
+                <span className="info-icon">⚡</span>
+                <span className="info-text">빠른 회원가입</span>
+              </div>
+              <div className="info-item">
+                <span className="info-icon">✨</span>
+                <span className="info-text">간편한 정보 입력</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <style jsx>{`
+        .step1-container {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          min-height: 60vh;
+          padding: 24px;
+        }
+
+        .step1-card {
+          background: rgba(255, 255, 255, 0.95);
+          backdrop-filter: blur(20px);
+          -webkit-backdrop-filter: blur(20px);
+          border-radius: 24px;
+          padding: 48px;
+          max-width: 480px;
+          width: 100%;
+          box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+          border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+
+        .step1-header {
+          text-align: center;
+          margin-bottom: 40px;
+        }
+
+        .step1-title {
+          font-size: 28px;
+          font-weight: 800;
+          color: #1a1a1a;
+          margin: 0 0 16px 0;
+          letter-spacing: -0.5px;
+        }
+
+        .step1-description {
+          font-size: 15px;
+          color: #666;
+          line-height: 1.6;
+          margin: 0;
+        }
+
+        .step1-content {
+          display: flex;
+          flex-direction: column;
+          gap: 20px;
+        }
+
+        .error-message {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          padding: 16px;
+          background: rgba(239, 68, 68, 0.1);
+          border-radius: 12px;
+          border: 1px solid rgba(239, 68, 68, 0.2);
+        }
+
+        .error-icon {
+          font-size: 20px;
+          flex-shrink: 0;
+        }
+
+        .error-text {
+          font-size: 14px;
+          color: #dc2626;
+          font-weight: 500;
+          line-height: 1.5;
+        }
+
+        .divider {
+          position: relative;
+          text-align: center;
+          margin: 12px 0;
+        }
+
+        .divider::before {
+          content: '';
+          position: absolute;
+          top: 50%;
+          left: 0;
+          right: 0;
+          height: 1px;
+          background: linear-gradient(
+            to right,
+            transparent,
+            rgba(0, 0, 0, 0.1),
+            transparent
+          );
+        }
+
+        .divider-text {
+          position: relative;
+          display: inline-block;
+          padding: 0 16px;
+          background: rgba(255, 255, 255, 0.95);
+          font-size: 13px;
+          color: #999;
+          font-weight: 500;
+        }
+
+        .info-section {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          padding: 20px;
+          background: linear-gradient(135deg, rgba(102, 126, 234, 0.05) 0%, rgba(118, 75, 162, 0.05) 100%);
+          border-radius: 16px;
+          border: 1px solid rgba(102, 126, 234, 0.1);
+        }
+
+        .info-item {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+        }
+
+        .info-icon {
+          font-size: 20px;
+          flex-shrink: 0;
+        }
+
+        .info-text {
+          font-size: 14px;
+          color: #4a5568;
+          font-weight: 500;
+        }
+
+        @media (max-width: 768px) {
+          .step1-container {
+            padding: 16px;
+            min-height: 50vh;
+          }
+
+          .step1-card {
+            padding: 32px 24px;
+            border-radius: 20px;
+          }
+
+          .step1-title {
+            font-size: 24px;
+          }
+
+          .step1-description {
+            font-size: 14px;
+          }
+
+          .info-section {
+            padding: 16px;
+          }
+        }
+
+        @media (max-width: 480px) {
+          .step1-card {
+            padding: 28px 20px;
+          }
+
+          .step1-title {
+            font-size: 22px;
+          }
+
+          .step1-header {
+            margin-bottom: 32px;
+          }
+        }
+      `}</style>
+    </>
+  );
+};
+
+Step1AccountInfo.displayName = 'Step1AccountInfo';
+
+export default Step1AccountInfo;

--- a/app/signup/components/StepIndicator.tsx
+++ b/app/signup/components/StepIndicator.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import React from 'react';
+
+export interface Step {
+  number: number;
+  label: string;
+}
+
+export interface StepIndicatorProps {
+  currentStep: 1 | 2 | 3;
+  steps: Step[];
+}
+
+const StepIndicator = React.memo<StepIndicatorProps>(({ currentStep, steps }) => {
+  const getStepStatus = (stepNumber: number): 'completed' | 'in_progress' | 'pending' => {
+    if (stepNumber < currentStep) return 'completed';
+    if (stepNumber === currentStep) return 'in_progress';
+    return 'pending';
+  };
+
+  const getStepColor = (status: string) => {
+    const colorMap = {
+      completed: '#10b981', // 초록색
+      in_progress: '#667eea', // 보라색
+      pending: '#d1d5db', // 회색
+    };
+    return colorMap[status as keyof typeof colorMap];
+  };
+
+  return (
+    <>
+      <div className="step-indicator" role="progressbar" aria-valuenow={currentStep} aria-valuemin={1} aria-valuemax={3}>
+        {steps.map((step, index) => {
+          const status = getStepStatus(step.number);
+          const isLastStep = index === steps.length - 1;
+
+          return (
+            <div key={step.number} className="step-item">
+              {/* Step Circle */}
+              <div className={`step-circle ${status}`}>
+                {status === 'completed' ? (
+                  <svg className="check-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  <span className="step-number">{step.number}</span>
+                )}
+              </div>
+
+              {/* Step Label */}
+              <div className={`step-label ${status}`}>
+                {step.label}
+              </div>
+
+              {/* Connector Line */}
+              {!isLastStep && (
+                <div className="connector-container">
+                  <div className={`connector-line ${status}`}></div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <style jsx>{`
+        .step-indicator {
+          display: flex;
+          align-items: flex-start;
+          justify-content: center;
+          gap: 8px;
+          padding: 24px 0;
+          margin: 0 auto;
+          max-width: 600px;
+        }
+
+        .step-item {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          flex: 1;
+          position: relative;
+        }
+
+        .step-circle {
+          width: 48px;
+          height: 48px;
+          border-radius: 50%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-weight: 700;
+          font-size: 18px;
+          transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+          z-index: 2;
+        }
+
+        .step-circle.completed {
+          background: #10b981;
+          color: white;
+          animation: pulse 0.5s ease-out;
+        }
+
+        .step-circle.in_progress {
+          background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+          color: white;
+          animation: glow 2s ease-in-out infinite;
+        }
+
+        .step-circle.pending {
+          background: #f3f4f6;
+          color: #9ca3af;
+          border: 2px solid #e5e7eb;
+        }
+
+        .check-icon {
+          width: 24px;
+          height: 24px;
+        }
+
+        .step-number {
+          font-size: 18px;
+        }
+
+        .step-label {
+          margin-top: 12px;
+          font-size: 14px;
+          font-weight: 600;
+          text-align: center;
+          transition: color 0.3s ease;
+          white-space: nowrap;
+        }
+
+        .step-label.completed {
+          color: #10b981;
+        }
+
+        .step-label.in_progress {
+          color: #667eea;
+        }
+
+        .step-label.pending {
+          color: #9ca3af;
+        }
+
+        .connector-container {
+          position: absolute;
+          top: 24px;
+          left: calc(50% + 24px);
+          right: calc(-50% + 24px);
+          height: 4px;
+          z-index: 1;
+        }
+
+        .connector-line {
+          height: 100%;
+          border-radius: 2px;
+          transition: all 0.5s ease-in-out;
+        }
+
+        .connector-line.completed {
+          background: linear-gradient(90deg, #10b981 0%, #10b981 100%);
+          animation: fillLine 0.5s ease-out;
+        }
+
+        .connector-line.in_progress {
+          background: linear-gradient(90deg, #667eea 0%, #d1d5db 100%);
+        }
+
+        .connector-line.pending {
+          background: #e5e7eb;
+        }
+
+        @keyframes pulse {
+          0% {
+            transform: scale(1);
+            box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+          }
+          50% {
+            transform: scale(1.1);
+            box-shadow: 0 6px 20px rgba(16, 185, 129, 0.5);
+          }
+          100% {
+            transform: scale(1);
+            box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+          }
+        }
+
+        @keyframes glow {
+          0%, 100% {
+            box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+          }
+          50% {
+            box-shadow: 0 6px 20px rgba(102, 126, 234, 0.6);
+          }
+        }
+
+        @keyframes fillLine {
+          from {
+            transform: scaleX(0);
+            transform-origin: left;
+          }
+          to {
+            transform: scaleX(1);
+            transform-origin: left;
+          }
+        }
+
+        /* 반응형 디자인 */
+        @media (max-width: 768px) {
+          .step-indicator {
+            gap: 4px;
+            padding: 16px 0;
+          }
+
+          .step-circle {
+            width: 40px;
+            height: 40px;
+            font-size: 16px;
+          }
+
+          .check-icon {
+            width: 20px;
+            height: 20px;
+          }
+
+          .step-number {
+            font-size: 16px;
+          }
+
+          .step-label {
+            font-size: 12px;
+            margin-top: 8px;
+          }
+
+          .connector-container {
+            top: 20px;
+            left: calc(50% + 20px);
+            right: calc(-50% + 20px);
+            height: 3px;
+          }
+        }
+
+        @media (max-width: 480px) {
+          .step-circle {
+            width: 36px;
+            height: 36px;
+            font-size: 14px;
+          }
+
+          .step-label {
+            font-size: 11px;
+          }
+        }
+      `}</style>
+    </>
+  );
+});
+
+StepIndicator.displayName = 'StepIndicator';
+
+export default StepIndicator;

--- a/lib/types/signup.ts
+++ b/lib/types/signup.ts
@@ -1,0 +1,79 @@
+/**
+ * Signup wizard type definitions for Swing Connect
+ */
+
+import type { DanceLevel, AuthProvider } from './auth';
+
+export interface SignupState {
+  // Current step in the wizard (1, 2, or 3)
+  currentStep: 1 | 2 | 3;
+
+  // Step 1: Account information (from social login)
+  accountData: {
+    provider: AuthProvider | null;
+    uid: string;
+    email: string;
+    displayName: string;
+    photoURL: string;
+  };
+
+  // Step 2: Profile information
+  profileData: {
+    nickname: string;
+    danceLevel: DanceLevel;
+    location: string;
+    bio: string;
+    interests: string[];
+  };
+
+  // Step 3: Terms agreement
+  termsData: {
+    serviceTerms: boolean;
+    privacyPolicy: boolean;
+    marketingConsent: boolean;
+  };
+
+  // Error handling
+  errors: Record<string, string>;
+
+  // Loading state
+  loading: boolean;
+}
+
+export const INITIAL_SIGNUP_STATE: SignupState = {
+  currentStep: 1,
+  accountData: {
+    provider: null,
+    uid: '',
+    email: '',
+    displayName: '',
+    photoURL: '',
+  },
+  profileData: {
+    nickname: '',
+    danceLevel: 'beginner',
+    location: '',
+    bio: '',
+    interests: [],
+  },
+  termsData: {
+    serviceTerms: false,
+    privacyPolicy: false,
+    marketingConsent: false,
+  },
+  errors: {},
+  loading: false,
+};
+
+export const SIGNUP_STORAGE_KEY = 'swing-connect-signup-progress';
+
+export interface Step {
+  number: 1 | 2 | 3;
+  label: string;
+}
+
+export const SIGNUP_STEPS: Step[] = [
+  { number: 1, label: '소셜 로그인' },
+  { number: 2, label: '프로필 정보' },
+  { number: 3, label: '약관 동의' },
+];


### PR DESCRIPTION
## Summary
Implements Issue #67 - 회원가입 Step 1 - 소셜 로그인 선택 UI 구현

This PR adds the first step of the signup wizard with Google social login functionality.

## Changes

### New Components
- **Step1AccountInfo** - Google login UI with comprehensive error handling
- **SignupButton** - Reusable button component (from issue-66 branch)
- **StepIndicator** - Progress indicator (from issue-66 branch)
- **signup types** - TypeScript definitions for signup state

### Features
✅ Google social login with Firebase integration  
✅ Comprehensive error handling (popup blocked, cancelled, network errors)  
✅ Auto-advance to Step 2 on success  
✅ Glassmorphism design matching app theme  
✅ Responsive mobile-first layout  
✅ Full accessibility support (ARIA labels, alerts)

### Testing
- **32 comprehensive tests** - all passing ✅
- Coverage: rendering, login flow, errors, loading states, accessibility
- No new lint warnings or type errors

## Technical Highlights

### Error Handling
Prioritized error handling for better UX:
1. Firebase error codes (popup-blocked, popup-closed-by-user, network-request-failed)
2. Custom error messages from Firebase
3. Generic fallback message

### State Management
- Local state for loading and errors
- Parent state updates via callbacks (onUpdateAccountData, onNext)
- Clean separation of concerns

## Screenshots
Google login UI with error handling and loading states

## Testing Instructions
```bash
npm test -- Step1AccountInfo.test.tsx
npm run type-check
npm run lint
```

## Related Issues
Closes #67

## Next Steps
- Issue #68: Step 2 - Profile information input
- Issue #69: Step 3 - Terms agreement
- Complete signup wizard integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>