### PR TITLE
feat: Implement Step2ProfileInfo with profile input fields

### DIFF
--- a/__tests__/app/signup/components/Step2ProfileInfo.test.tsx
+++ b/__tests__/app/signup/components/Step2ProfileInfo.test.tsx
@@ -1,0 +1,837 @@
+/**
+ * Step2ProfileInfo 컴포넌트 통합 테스트
+ * 프로필 정보 입력 폼의 모든 기능과 검증 로직을 테스트합니다.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Step2ProfileInfo, { Step2ProfileInfoProps } from '@/app/signup/components/Step2ProfileInfo';
+import { DANCE_LEVELS, REGIONS, DANCE_STYLES, VALIDATION } from '@/lib/constants/profile';
+import type { DanceLevel } from '@/lib/types/auth';
+
+// SignupButton 컴포넌트 모킹
+jest.mock('@/app/signup/components/SignupButton', () => {
+  return function MockSignupButton({ children, onClick, disabled, variant, ...props }: any) {
+    return (
+      <button
+        onClick={onClick}
+        disabled={disabled}
+        data-variant={variant}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  };
+});
+
+// 기본 프로필 데이터
+const mockProfileData = {
+  nickname: '',
+  danceLevel: 'beginner' as DanceLevel,
+  location: '',
+  bio: '',
+  interests: [] as string[],
+};
+
+// 기본 props
+const defaultProps: Step2ProfileInfoProps = {
+  profileData: mockProfileData,
+  onNext: jest.fn(),
+  onBack: jest.fn(),
+  onUpdateProfileData: jest.fn(),
+};
+
+describe('Step2ProfileInfo 컴포넌트', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('1. 초기 렌더링', () => {
+    it('헤더와 제목이 렌더링되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      expect(screen.getByText('프로필 정보 입력')).toBeInTheDocument();
+      expect(screen.getByText(/스윙댄스 커뮤니티에서 사용할/)).toBeInTheDocument();
+    });
+
+    it('모든 필수 필드 라벨이 표시되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      expect(screen.getByLabelText(/닉네임/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/댄스 레벨 선택/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/활동 지역/)).toBeInTheDocument();
+    });
+
+    it('선택 필드 라벨이 (선택) 표시와 함께 렌더링되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      expect(screen.getByText('자기소개')).toBeInTheDocument();
+      expect(screen.getAllByText('(선택)')).toHaveLength(2); // Bio and interests
+      expect(screen.getByText('관심 댄스 스타일')).toBeInTheDocument();
+    });
+
+    it('닉네임 입력 필드가 올바른 placeholder를 가져야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByPlaceholderText('닉네임을 입력하세요 (2-20자)');
+      expect(nicknameInput).toBeInTheDocument();
+      expect(nicknameInput).toHaveAttribute('maxLength', '20');
+    });
+
+    it('자기소개 textarea가 올바른 placeholder를 가져야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const bioTextarea = screen.getByPlaceholderText('간단한 자기소개를 작성해주세요');
+      expect(bioTextarea).toBeInTheDocument();
+      expect(bioTextarea).toHaveAttribute('rows', '4');
+    });
+
+    it('이전/다음 버튼이 렌더링되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      expect(screen.getByTestId('back-button')).toBeInTheDocument();
+      expect(screen.getByTestId('next-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('2. 닉네임 검증', () => {
+    it('닉네임이 비어있으면 필수 에러 메시지가 표시되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        expect(screen.getByText(VALIDATION.NICKNAME.ERROR_MESSAGES.REQUIRED)).toBeInTheDocument();
+      });
+    });
+
+    it('닉네임이 2자 미만이면 최소 길이 에러가 표시되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.change(nicknameInput, { target: { value: 'a' } });
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        expect(screen.getByText(VALIDATION.NICKNAME.ERROR_MESSAGES.MIN_LENGTH)).toBeInTheDocument();
+      });
+    });
+
+    it('닉네임이 20자를 초과하면 최대 길이 에러가 표시되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.change(nicknameInput, { target: { value: 'a'.repeat(21) } });
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        expect(screen.getByText(VALIDATION.NICKNAME.ERROR_MESSAGES.MAX_LENGTH)).toBeInTheDocument();
+      });
+    });
+
+    it('닉네임에 특수문자가 포함되면 패턴 에러가 표시되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.change(nicknameInput, { target: { value: 'test@123' } });
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        expect(screen.getByText(VALIDATION.NICKNAME.ERROR_MESSAGES.PATTERN)).toBeInTheDocument();
+      });
+    });
+
+    it('유효한 한글 닉네임이 허용되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.change(nicknameInput, { target: { value: '스윙댄서' } });
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        expect(screen.queryByText(VALIDATION.NICKNAME.ERROR_MESSAGES.PATTERN)).not.toBeInTheDocument();
+      });
+    });
+
+    it('유효한 영문+숫자 닉네임이 허용되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.change(nicknameInput, { target: { value: 'swing123' } });
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        expect(screen.queryByText(VALIDATION.NICKNAME.ERROR_MESSAGES.PATTERN)).not.toBeInTheDocument();
+      });
+    });
+
+    it('닉네임 변경 시 에러가 클리어되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+
+      // 에러 발생
+      fireEvent.blur(nicknameInput);
+      await waitFor(() => {
+        expect(screen.getByText(VALIDATION.NICKNAME.ERROR_MESSAGES.REQUIRED)).toBeInTheDocument();
+      });
+
+      // 유효한 값 입력
+      fireEvent.change(nicknameInput, { target: { value: 'validname' } });
+
+      expect(screen.queryByText(VALIDATION.NICKNAME.ERROR_MESSAGES.REQUIRED)).not.toBeInTheDocument();
+    });
+
+    it('닉네임 입력 시 부모 컴포넌트가 업데이트되어야 함', () => {
+      const onUpdateProfileData = jest.fn();
+      render(<Step2ProfileInfo {...defaultProps} onUpdateProfileData={onUpdateProfileData} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.change(nicknameInput, { target: { value: 'testuser' } });
+
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ nickname: 'testuser' });
+    });
+  });
+
+  describe('3. 댄스 레벨 선택', () => {
+    it('모든 댄스 레벨 옵션이 표시되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const select = screen.getByLabelText(/댄스 레벨 선택/);
+
+      DANCE_LEVELS.forEach(level => {
+        expect(screen.getByText(`${level.label} - ${level.description}`)).toBeInTheDocument();
+      });
+    });
+
+    it('기본값이 beginner로 설정되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const select = screen.getByLabelText(/댄스 레벨 선택/) as HTMLSelectElement;
+      expect(select.value).toBe('beginner');
+    });
+
+    it('댄스 레벨 변경 시 부모 컴포넌트가 업데이트되어야 함', () => {
+      const onUpdateProfileData = jest.fn();
+      render(<Step2ProfileInfo {...defaultProps} onUpdateProfileData={onUpdateProfileData} />);
+
+      const select = screen.getByLabelText(/댄스 레벨 선택/);
+      fireEvent.change(select, { target: { value: 'advanced' } });
+
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ danceLevel: 'advanced' });
+    });
+
+    it('props로 전달된 danceLevel이 반영되어야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: { ...mockProfileData, danceLevel: 'professional' as DanceLevel },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const select = screen.getByLabelText(/댄스 레벨 선택/) as HTMLSelectElement;
+      expect(select.value).toBe('professional');
+    });
+  });
+
+  describe('4. 활동 지역 선택', () => {
+    it('기본 placeholder 옵션이 표시되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      expect(screen.getByText('지역을 선택하세요')).toBeInTheDocument();
+    });
+
+    it('모든 지역 옵션이 표시되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      REGIONS.forEach(region => {
+        expect(screen.getByText(region.label)).toBeInTheDocument();
+      });
+    });
+
+    it('지역 미선택 시 필수 에러가 표시되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const locationSelect = screen.getByLabelText(/활동 지역/);
+      fireEvent.blur(locationSelect);
+
+      await waitFor(() => {
+        expect(screen.getByText(VALIDATION.LOCATION.ERROR_MESSAGES.REQUIRED)).toBeInTheDocument();
+      });
+    });
+
+    it('지역 선택 시 부모 컴포넌트가 업데이트되어야 함', () => {
+      const onUpdateProfileData = jest.fn();
+      render(<Step2ProfileInfo {...defaultProps} onUpdateProfileData={onUpdateProfileData} />);
+
+      const locationSelect = screen.getByLabelText(/활동 지역/);
+      fireEvent.change(locationSelect, { target: { value: 'seoul' } });
+
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ location: 'seoul' });
+    });
+
+    it('지역 선택 시 에러가 클리어되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const locationSelect = screen.getByLabelText(/활동 지역/);
+
+      // 에러 발생
+      fireEvent.blur(locationSelect);
+      await waitFor(() => {
+        expect(screen.getByText(VALIDATION.LOCATION.ERROR_MESSAGES.REQUIRED)).toBeInTheDocument();
+      });
+
+      // 지역 선택
+      fireEvent.change(locationSelect, { target: { value: 'seoul' } });
+
+      expect(screen.queryByText(VALIDATION.LOCATION.ERROR_MESSAGES.REQUIRED)).not.toBeInTheDocument();
+    });
+
+    it('props로 전달된 location이 반영되어야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: { ...mockProfileData, location: 'busan' },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const locationSelect = screen.getByLabelText(/활동 지역/) as HTMLSelectElement;
+      expect(locationSelect.value).toBe('busan');
+    });
+  });
+
+  describe('5. 자기소개 (선택 필드)', () => {
+    it('자기소개 입력 시 부모 컴포넌트가 업데이트되어야 함', () => {
+      const onUpdateProfileData = jest.fn();
+      render(<Step2ProfileInfo {...defaultProps} onUpdateProfileData={onUpdateProfileData} />);
+
+      const bioTextarea = screen.getByLabelText(/자기소개/);
+      fireEvent.change(bioTextarea, { target: { value: '안녕하세요' } });
+
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ bio: '안녕하세요' });
+    });
+
+    it('글자 수 카운터가 표시되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      expect(screen.getByText(`0 / ${VALIDATION.BIO.MAX_LENGTH}`)).toBeInTheDocument();
+    });
+
+    it('입력 시 글자 수 카운터가 업데이트되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const bioTextarea = screen.getByLabelText(/자기소개/);
+      const testText = '안녕하세요. 스윙댄스 초보입니다.';
+      fireEvent.change(bioTextarea, { target: { value: testText } });
+
+      expect(screen.getByText(`${testText.length} / ${VALIDATION.BIO.MAX_LENGTH}`)).toBeInTheDocument();
+    });
+
+    it('200자 초과 시 에러 메시지가 표시되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const bioTextarea = screen.getByLabelText(/자기소개/);
+      const longText = 'a'.repeat(201);
+      fireEvent.change(bioTextarea, { target: { value: longText } });
+      fireEvent.blur(bioTextarea);
+
+      await waitFor(() => {
+        expect(screen.getByText(VALIDATION.BIO.ERROR_MESSAGES.MAX_LENGTH)).toBeInTheDocument();
+      });
+    });
+
+    it('200자 초과 시 글자 수가 over-limit 스타일을 가져야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const bioTextarea = screen.getByLabelText(/자기소개/);
+      const longText = 'a'.repeat(201);
+      fireEvent.change(bioTextarea, { target: { value: longText } });
+
+      const counter = screen.getByText(`201 / ${VALIDATION.BIO.MAX_LENGTH}`);
+      expect(counter).toHaveClass('over-limit');
+    });
+
+    it('200자 이하는 에러가 없어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const bioTextarea = screen.getByLabelText(/자기소개/);
+      const validText = 'a'.repeat(200);
+      fireEvent.change(bioTextarea, { target: { value: validText } });
+      fireEvent.blur(bioTextarea);
+
+      await waitFor(() => {
+        expect(screen.queryByText(VALIDATION.BIO.ERROR_MESSAGES.MAX_LENGTH)).not.toBeInTheDocument();
+      });
+    });
+
+    it('빈 값이어도 에러가 없어야 함 (선택 필드)', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const bioTextarea = screen.getByLabelText(/자기소개/);
+      fireEvent.blur(bioTextarea);
+
+      await waitFor(() => {
+        expect(screen.queryByText(VALIDATION.BIO.ERROR_MESSAGES.MAX_LENGTH)).not.toBeInTheDocument();
+      });
+    });
+
+    it('props로 전달된 bio가 반영되어야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: { ...mockProfileData, bio: '스윙댄스를 사랑합니다' },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const bioTextarea = screen.getByLabelText(/자기소개/) as HTMLTextAreaElement;
+      expect(bioTextarea.value).toBe('스윙댄스를 사랑합니다');
+    });
+  });
+
+  describe('6. 관심 댄스 스타일 (선택 필드)', () => {
+    it('모든 댄스 스타일 칩이 렌더링되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      DANCE_STYLES.forEach(style => {
+        expect(screen.getByText(style.label)).toBeInTheDocument();
+      });
+    });
+
+    it('댄스 스타일 아이콘이 표시되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      DANCE_STYLES.forEach(style => {
+        if (style.icon) {
+          expect(screen.getByText(style.icon)).toBeInTheDocument();
+        }
+      });
+    });
+
+    it('칩 클릭 시 선택 상태가 토글되어야 함', () => {
+      const onUpdateProfileData = jest.fn();
+      render(<Step2ProfileInfo {...defaultProps} onUpdateProfileData={onUpdateProfileData} />);
+
+      const lindyHopChip = screen.getByLabelText(/린디합/);
+
+      // 첫 번째 클릭 - 선택
+      fireEvent.click(lindyHopChip);
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ interests: ['lindy-hop'] });
+
+      // 두 번째 클릭 - 선택 해제
+      fireEvent.click(lindyHopChip);
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ interests: [] });
+    });
+
+    it('여러 댄스 스타일을 동시에 선택할 수 있어야 함', () => {
+      const onUpdateProfileData = jest.fn();
+      render(<Step2ProfileInfo {...defaultProps} onUpdateProfileData={onUpdateProfileData} />);
+
+      const lindyHopChip = screen.getByLabelText(/린디합/);
+      const charlestonChip = screen.getByLabelText(/찰스턴/);
+
+      fireEvent.click(lindyHopChip);
+      fireEvent.click(charlestonChip);
+
+      expect(onUpdateProfileData).toHaveBeenLastCalledWith({ interests: ['lindy-hop', 'charleston'] });
+    });
+
+    it('선택된 칩이 selected 클래스를 가져야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: { ...mockProfileData, interests: ['lindy-hop'] },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const lindyHopChip = screen.getByLabelText(/린디합 선택됨/);
+      expect(lindyHopChip).toHaveClass('selected');
+    });
+
+    it('선택된 칩의 aria-pressed가 true여야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: { ...mockProfileData, interests: ['blues'] },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const bluesChip = screen.getByLabelText(/블루스 선택됨/);
+      expect(bluesChip).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('선택되지 않은 칩의 aria-pressed가 false여야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const lindyHopChip = screen.getByLabelText(/린디합 선택 안됨/);
+      expect(lindyHopChip).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('props로 전달된 interests가 반영되어야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: { ...mockProfileData, interests: ['lindy-hop', 'balboa'] },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      expect(screen.getByLabelText(/린디합 선택됨/)).toHaveClass('selected');
+      expect(screen.getByLabelText(/발보아 선택됨/)).toHaveClass('selected');
+    });
+  });
+
+  describe('7. 버튼 동작', () => {
+    it('이전 버튼 클릭 시 onBack이 호출되어야 함', () => {
+      const onBack = jest.fn();
+      render(<Step2ProfileInfo {...defaultProps} onBack={onBack} />);
+
+      const prevButton = screen.getByTestId('back-button');
+      fireEvent.click(prevButton);
+
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('다음 버튼이 필수 필드 미입력 시 비활성화되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton).toBeDisabled();
+    });
+
+    it('닉네임만 입력 시 다음 버튼이 비활성화되어야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: { ...mockProfileData, nickname: 'testuser' },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton).toBeDisabled();
+    });
+
+    it('닉네임과 지역 입력 시 다음 버튼이 활성화되어야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: {
+          ...mockProfileData,
+          nickname: 'testuser',
+          location: 'seoul',
+        },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton).not.toBeDisabled();
+    });
+
+    it('유효한 폼 상태에서 다음 버튼 클릭 시 onNext가 호출되어야 함', () => {
+      const onNext = jest.fn();
+      const props = {
+        ...defaultProps,
+        onNext,
+        profileData: {
+          ...mockProfileData,
+          nickname: 'testuser',
+          location: 'seoul',
+        },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      fireEvent.click(nextButton);
+
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('잘못된 닉네임으로 다음 버튼이 비활성화되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      // 필수 필드가 비어있으면 버튼 비활성화
+      expect(nextButton).toBeDisabled();
+    });
+
+    it('자기소개 200자 초과 시 다음 버튼 클릭이 막혀야 함', () => {
+      const onNext = jest.fn();
+      const props = {
+        ...defaultProps,
+        onNext,
+        profileData: {
+          ...mockProfileData,
+          nickname: 'testuser',
+          location: 'seoul',
+          bio: 'a'.repeat(201),
+        },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton).toBeDisabled();
+    });
+  });
+
+  describe('8. 폼 검증', () => {
+    it('모든 필수 필드가 유효할 때 폼이 유효해야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: {
+          ...mockProfileData,
+          nickname: 'validuser',
+          location: 'seoul',
+        },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton).not.toBeDisabled();
+    });
+
+    it('닉네임이 유효하지 않으면 폼이 무효해야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: {
+          ...mockProfileData,
+          nickname: 'a', // too short
+          location: 'seoul',
+        },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton).toBeDisabled();
+    });
+
+    it('지역이 선택되지 않으면 폼이 무효해야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: {
+          ...mockProfileData,
+          nickname: 'validuser',
+          location: '',
+        },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton).toBeDisabled();
+    });
+
+    it('선택 필드(자기소개, 댄스 스타일)는 폼 유효성에 영향을 주지 않아야 함', () => {
+      const props = {
+        ...defaultProps,
+        profileData: {
+          ...mockProfileData,
+          nickname: 'validuser',
+          location: 'seoul',
+          bio: '',
+          interests: [],
+        },
+      };
+      render(<Step2ProfileInfo {...props} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      expect(nextButton).not.toBeDisabled();
+    });
+
+    it('필수 필드가 비어있으면 다음 버튼이 비활성화되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      // 필수 필드(닉네임, 지역)가 비어있으므로 버튼 비활성화
+      expect(nextButton).toBeDisabled();
+    });
+
+    it('실시간 검증이 blur 이벤트에서 동작해야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+
+      // focus 후 blur
+      fireEvent.focus(nicknameInput);
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        expect(screen.getByText(VALIDATION.NICKNAME.ERROR_MESSAGES.REQUIRED)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('9. 접근성', () => {
+    it('필수 필드에 required 마커가 표시되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameLabel = screen.getByText('닉네임').closest('.field-label');
+      const danceLevelLabel = screen.getByText('댄스 레벨').closest('.field-label');
+      const locationLabel = screen.getByText('활동 지역').closest('.field-label');
+
+      expect(nicknameLabel).toHaveClass('required');
+      expect(danceLevelLabel).toHaveClass('required');
+      expect(locationLabel).toHaveClass('required');
+    });
+
+    it('에러 메시지에 role="alert"이 있어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        const errorMessage = screen.getByText(VALIDATION.NICKNAME.ERROR_MESSAGES.REQUIRED);
+        expect(errorMessage).toHaveAttribute('role', 'alert');
+      });
+    });
+
+    it('에러 상태의 입력 필드에 aria-invalid가 true여야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        expect(nicknameInput).toHaveAttribute('aria-invalid', 'true');
+      });
+    });
+
+    it('에러 메시지가 aria-describedby로 연결되어야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        expect(nicknameInput).toHaveAttribute('aria-describedby', 'nickname-error');
+        expect(screen.getByText(VALIDATION.NICKNAME.ERROR_MESSAGES.REQUIRED)).toHaveAttribute('id', 'nickname-error');
+      });
+    });
+
+    it('글자 수 카운터에 aria-live가 있어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const counter = screen.getByText(`0 / ${VALIDATION.BIO.MAX_LENGTH}`);
+      expect(counter).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('댄스 스타일 칩 컨테이너에 role="group"이 있어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const chipContainer = screen.getByRole('group', { name: '관심 댄스 스타일 선택' });
+      expect(chipContainer).toBeInTheDocument();
+    });
+
+    it('버튼에 적절한 aria-label이 있어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      expect(screen.getByTestId('back-button')).toHaveAttribute('aria-label', '이전 단계로');
+      expect(screen.getByTestId('next-button')).toHaveAttribute('aria-label', '다음 단계로');
+    });
+
+    it('댄스 레벨 select에 aria-label이 있어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const select = screen.getByLabelText(/댄스 레벨 선택/);
+      expect(select).toHaveAttribute('aria-label', '댄스 레벨 선택');
+    });
+
+    it('자기소개 textarea에 bio-counter가 aria-describedby로 연결되어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const bioTextarea = screen.getByLabelText(/자기소개/);
+      expect(bioTextarea).toHaveAttribute('aria-describedby', 'bio-counter');
+    });
+  });
+
+  describe('10. 반응형 및 스타일', () => {
+    it('컴포넌트가 step2-container 클래스를 가져야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const container = screen.getByText('프로필 정보 입력').closest('.step2-container');
+      expect(container).toBeInTheDocument();
+    });
+
+    it('카드 컨테이너가 glassmorphism 스타일을 가져야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const card = screen.getByText('프로필 정보 입력').closest('.step2-card');
+      expect(card).toBeInTheDocument();
+    });
+
+    it('에러 상태의 입력 필드가 error 클래스를 가져야 함', async () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.blur(nicknameInput);
+
+      await waitFor(() => {
+        expect(nicknameInput).toHaveClass('error');
+      });
+    });
+
+    it('버튼 그룹이 적절한 레이아웃을 가져야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const prevButton = screen.getByTestId('back-button');
+      const nextButton = screen.getByTestId('next-button');
+
+      expect(prevButton.style.flex).toContain('1');
+      expect(nextButton.style.flex).toContain('2');
+    });
+
+    it('댄스 스타일 칩이 chip-container 안에 있어야 함', () => {
+      render(<Step2ProfileInfo {...defaultProps} />);
+
+      const chipContainer = document.querySelector('.chip-container');
+      expect(chipContainer).toBeInTheDocument();
+
+      const lindyHopChip = screen.getByLabelText(/린디합/);
+      expect(chipContainer).toContainElement(lindyHopChip);
+    });
+  });
+
+  describe('11. 데이터 동기화', () => {
+    it('props 변경 시 로컬 상태가 업데이트되어야 함', () => {
+      const { rerender } = render(<Step2ProfileInfo {...defaultProps} />);
+
+      const updatedProps = {
+        ...defaultProps,
+        profileData: {
+          ...mockProfileData,
+          nickname: 'newname',
+          location: 'busan',
+        },
+      };
+      rerender(<Step2ProfileInfo {...updatedProps} />);
+
+      const nicknameInput = screen.getByLabelText(/닉네임/) as HTMLInputElement;
+      const locationSelect = screen.getByLabelText(/활동 지역/) as HTMLSelectElement;
+
+      expect(nicknameInput.value).toBe('newname');
+      expect(locationSelect.value).toBe('busan');
+    });
+
+    it('모든 필드 변경 시 onUpdateProfileData가 올바른 데이터로 호출되어야 함', () => {
+      const onUpdateProfileData = jest.fn();
+      render(<Step2ProfileInfo {...defaultProps} onUpdateProfileData={onUpdateProfileData} />);
+
+      // 닉네임 변경
+      const nicknameInput = screen.getByLabelText(/닉네임/);
+      fireEvent.change(nicknameInput, { target: { value: 'dancer' } });
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ nickname: 'dancer' });
+
+      // 댄스 레벨 변경
+      const danceLevelSelect = screen.getByLabelText(/댄스 레벨 선택/);
+      fireEvent.change(danceLevelSelect, { target: { value: 'intermediate' } });
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ danceLevel: 'intermediate' });
+
+      // 지역 변경
+      const locationSelect = screen.getByLabelText(/활동 지역/);
+      fireEvent.change(locationSelect, { target: { value: 'seoul' } });
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ location: 'seoul' });
+
+      // 자기소개 변경
+      const bioTextarea = screen.getByLabelText(/자기소개/);
+      fireEvent.change(bioTextarea, { target: { value: 'Hello' } });
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ bio: 'Hello' });
+
+      // 댄스 스타일 변경
+      const lindyHopChip = screen.getByLabelText(/린디합/);
+      fireEvent.click(lindyHopChip);
+      expect(onUpdateProfileData).toHaveBeenCalledWith({ interests: ['lindy-hop'] });
+    });
+  });
+});

--- a/app/signup/components/SignupButton.tsx
+++ b/app/signup/components/SignupButton.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import React from 'react';
+
+export interface SignupButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant: 'primary' | 'social-google';
+  loading?: boolean;
+  children: React.ReactNode;
+}
+
+const SignupButton = React.memo<SignupButtonProps>(
+  ({ variant, loading = false, disabled, children, className = '', ...props }) => {
+    const getVariantStyles = () => {
+      const baseStyles = `
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        width: 100%;
+        height: 56px;
+        border: none;
+        border-radius: 14px;
+        font-size: 16px;
+        font-weight: 700;
+        cursor: ${disabled || loading ? 'not-allowed' : 'pointer'};
+        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        position: relative;
+        overflow: hidden;
+        opacity: ${disabled || loading ? 0.6 : 1};
+      `;
+
+      const variantMap = {
+        'primary': `
+          ${baseStyles}
+          background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+          color: white;
+          box-shadow: 0 4px 16px rgba(102, 126, 234, 0.3);
+        `,
+        'social-google': `
+          ${baseStyles}
+          background: linear-gradient(135deg, #4285f4 0%, #357ae8 100%);
+          color: white;
+          box-shadow: 0 4px 16px rgba(66, 133, 244, 0.3);
+        `,
+      };
+
+      return variantMap[variant];
+    };
+
+    const getHoverStyles = () => {
+      const hoverMap = {
+        'primary': 'box-shadow: 0 8px 24px rgba(102, 126, 234, 0.5);',
+        'social-google': 'box-shadow: 0 8px 24px rgba(66, 133, 244, 0.5);',
+      };
+
+      return hoverMap[variant];
+    };
+
+    const getIcon = () => {
+      if (loading) {
+        return <span className="spinner">⏳</span>;
+      }
+
+      const iconMap = {
+        'primary': null,
+        'social-google': '🔵',
+      };
+
+      const icon = iconMap[variant];
+      return icon ? <span style={{ fontSize: '24px' }}>{icon}</span> : null;
+    };
+
+    return (
+      <>
+        <button
+          className={`signup-button ${className}`}
+          disabled={disabled || loading}
+          aria-busy={loading}
+          aria-label={loading ? '로딩 중...' : props['aria-label']}
+          {...props}
+        >
+          {getIcon()}
+          <span>{loading ? '로딩 중...' : children}</span>
+        </button>
+
+        <style jsx>{`
+          .signup-button {
+            ${getVariantStyles()}
+          }
+
+          .signup-button::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: -100%;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+            transition: left 0.5s;
+          }
+
+          .signup-button:hover::before {
+            left: 100%;
+          }
+
+          .signup-button:not(:disabled):hover {
+            transform: translateY(-3px) scale(1.02);
+            ${getHoverStyles()}
+          }
+
+          .signup-button:not(:disabled):active {
+            transform: translateY(-1px) scale(0.98);
+          }
+
+          .signup-button:focus-visible {
+            outline: none;
+            ring: 2px solid #693BF2;
+            ring-offset: 2px;
+          }
+
+          .spinner {
+            display: inline-block;
+            animation: spin 1s linear infinite;
+          }
+
+          @keyframes spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+          }
+
+          @media (max-width: 768px) {
+            .signup-button {
+              height: 52px;
+              font-size: 15px;
+            }
+          }
+        `}</style>
+      </>
+    );
+  }
+);
+
+SignupButton.displayName = 'SignupButton';
+
+export default SignupButton;

--- a/app/signup/components/Step2ProfileInfo.tsx
+++ b/app/signup/components/Step2ProfileInfo.tsx
@@ -1,0 +1,527 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import SignupButton from './SignupButton';
+import type { SignupState } from '@/lib/types/signup';
+import type { DanceLevel } from '@/lib/types/auth';
+import { DANCE_LEVELS, REGIONS, DANCE_STYLES, VALIDATION } from '@/lib/constants/profile';
+
+export interface Step2ProfileInfoProps {
+  profileData: SignupState['profileData'];
+  onNext: () => void;
+  onBack: () => void;
+  onUpdateProfileData: (data: Partial<SignupState['profileData']>) => void;
+}
+
+const Step2ProfileInfo: React.FC<Step2ProfileInfoProps> = ({
+  profileData,
+  onNext,
+  onBack,
+  onUpdateProfileData,
+}) => {
+  const [localData, setLocalData] = useState(profileData);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  // Sync with parent when profileData changes
+  useEffect(() => {
+    setLocalData(profileData);
+  }, [profileData]);
+
+  const validateNickname = (nickname: string): string | null => {
+    if (!nickname.trim()) {
+      return VALIDATION.NICKNAME.ERROR_MESSAGES.REQUIRED;
+    }
+    if (nickname.length < VALIDATION.NICKNAME.MIN_LENGTH) {
+      return VALIDATION.NICKNAME.ERROR_MESSAGES.MIN_LENGTH;
+    }
+    if (nickname.length > VALIDATION.NICKNAME.MAX_LENGTH) {
+      return VALIDATION.NICKNAME.ERROR_MESSAGES.MAX_LENGTH;
+    }
+    if (!VALIDATION.NICKNAME.PATTERN.test(nickname)) {
+      return VALIDATION.NICKNAME.ERROR_MESSAGES.PATTERN;
+    }
+    return null;
+  };
+
+  const validateLocation = (location: string): string | null => {
+    if (!location) {
+      return VALIDATION.LOCATION.ERROR_MESSAGES.REQUIRED;
+    }
+    return null;
+  };
+
+  const validateBio = (bio: string): string | null => {
+    if (bio.length > VALIDATION.BIO.MAX_LENGTH) {
+      return VALIDATION.BIO.ERROR_MESSAGES.MAX_LENGTH;
+    }
+    return null;
+  };
+
+  const handleFieldChange = (field: keyof SignupState['profileData'], value: any) => {
+    const newData = { ...localData, [field]: value };
+    setLocalData(newData);
+
+    // Clear error for this field
+    setErrors(prev => ({ ...prev, [field]: '' }));
+
+    // Update parent immediately
+    onUpdateProfileData({ [field]: value });
+  };
+
+  const handleBlur = (field: keyof SignupState['profileData']) => {
+    setTouched(prev => ({ ...prev, [field]: true }));
+
+    // Validate on blur
+    let error: string | null = null;
+    if (field === 'nickname') {
+      error = validateNickname(localData.nickname);
+    } else if (field === 'location') {
+      error = validateLocation(localData.location);
+    } else if (field === 'bio') {
+      error = validateBio(localData.bio);
+    }
+
+    if (error) {
+      setErrors(prev => ({ ...prev, [field]: error }));
+    }
+  };
+
+  const handleInterestToggle = (interestValue: string) => {
+    const currentInterests = localData.interests || [];
+    const newInterests = currentInterests.includes(interestValue)
+      ? currentInterests.filter(i => i !== interestValue)
+      : [...currentInterests, interestValue];
+
+    handleFieldChange('interests', newInterests);
+  };
+
+  const handleNext = () => {
+    // Validate all required fields
+    const nicknameError = validateNickname(localData.nickname);
+    const locationError = validateLocation(localData.location);
+    const bioError = validateBio(localData.bio);
+
+    const newErrors: Record<string, string> = {};
+    if (nicknameError) newErrors.nickname = nicknameError;
+    if (locationError) newErrors.location = locationError;
+    if (bioError) newErrors.bio = bioError;
+
+    setErrors(newErrors);
+
+    // Mark all required fields as touched
+    setTouched({
+      nickname: true,
+      danceLevel: true,
+      location: true,
+      bio: true,
+      interests: true,
+    });
+
+    // If no errors, proceed to next step
+    if (Object.keys(newErrors).length === 0) {
+      onNext();
+    }
+  };
+
+  const isFormValid =
+    !validateNickname(localData.nickname) &&
+    !validateLocation(localData.location) &&
+    !validateBio(localData.bio);
+
+  const bioLength = localData.bio.length;
+  const isBioOverLimit = bioLength > VALIDATION.BIO.MAX_LENGTH;
+
+  return (
+    <>
+      <div className="step2-container">
+        <div className="step2-card">
+          <div className="step2-header">
+            <h2 className="step2-title">프로필 정보 입력</h2>
+            <p className="step2-description">
+              스윙댄스 커뮤니티에서 사용할<br />
+              프로필 정보를 입력해주세요
+            </p>
+          </div>
+
+          <div className="step2-content">
+            {/* Nickname Field */}
+            <div className="field-group">
+              <label htmlFor="nickname" className="field-label required">
+                닉네임
+              </label>
+              <input
+                id="nickname"
+                type="text"
+                className={`field-input ${errors.nickname && touched.nickname ? 'error' : ''}`}
+                value={localData.nickname}
+                onChange={(e) => handleFieldChange('nickname', e.target.value)}
+                onBlur={() => handleBlur('nickname')}
+                placeholder="닉네임을 입력하세요 (2-20자)"
+                maxLength={VALIDATION.NICKNAME.MAX_LENGTH}
+                aria-invalid={!!(errors.nickname && touched.nickname)}
+                aria-describedby={errors.nickname && touched.nickname ? 'nickname-error' : undefined}
+              />
+              {errors.nickname && touched.nickname && (
+                <span id="nickname-error" className="field-error" role="alert">
+                  {errors.nickname}
+                </span>
+              )}
+            </div>
+
+            {/* Dance Level Field */}
+            <div className="field-group">
+              <label htmlFor="danceLevel" className="field-label required">
+                댄스 레벨
+              </label>
+              <select
+                id="danceLevel"
+                className="field-select"
+                value={localData.danceLevel}
+                onChange={(e) => handleFieldChange('danceLevel', e.target.value as DanceLevel)}
+                aria-label="댄스 레벨 선택"
+              >
+                {DANCE_LEVELS.map((level) => (
+                  <option key={level.value} value={level.value}>
+                    {level.label} - {level.description}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Location Field */}
+            <div className="field-group">
+              <label htmlFor="location" className="field-label required">
+                활동 지역
+              </label>
+              <select
+                id="location"
+                className={`field-select ${errors.location && touched.location ? 'error' : ''}`}
+                value={localData.location}
+                onChange={(e) => handleFieldChange('location', e.target.value)}
+                onBlur={() => handleBlur('location')}
+                aria-invalid={!!(errors.location && touched.location)}
+                aria-describedby={errors.location && touched.location ? 'location-error' : undefined}
+              >
+                <option value="">지역을 선택하세요</option>
+                {REGIONS.map((region) => (
+                  <option key={region.value} value={region.value}>
+                    {region.label}
+                  </option>
+                ))}
+              </select>
+              {errors.location && touched.location && (
+                <span id="location-error" className="field-error" role="alert">
+                  {errors.location}
+                </span>
+              )}
+            </div>
+
+            {/* Bio Field (Optional) */}
+            <div className="field-group">
+              <label htmlFor="bio" className="field-label">
+                자기소개 <span className="optional-label">(선택)</span>
+              </label>
+              <textarea
+                id="bio"
+                className={`field-textarea ${isBioOverLimit ? 'error' : ''}`}
+                value={localData.bio}
+                onChange={(e) => handleFieldChange('bio', e.target.value)}
+                onBlur={() => handleBlur('bio')}
+                placeholder="간단한 자기소개를 작성해주세요"
+                rows={4}
+                aria-invalid={isBioOverLimit}
+                aria-describedby="bio-counter"
+              />
+              <div
+                id="bio-counter"
+                className={`char-counter ${isBioOverLimit ? 'over-limit' : ''}`}
+                aria-live="polite"
+              >
+                {bioLength} / {VALIDATION.BIO.MAX_LENGTH}
+              </div>
+              {errors.bio && touched.bio && (
+                <span className="field-error" role="alert">
+                  {errors.bio}
+                </span>
+              )}
+            </div>
+
+            {/* Dance Styles (Optional) */}
+            <div className="field-group">
+              <label className="field-label">
+                관심 댄스 스타일 <span className="optional-label">(선택)</span>
+              </label>
+              <div className="chip-container" role="group" aria-label="관심 댄스 스타일 선택">
+                {DANCE_STYLES.map((style) => {
+                  const isSelected = localData.interests.includes(style.value);
+                  return (
+                    <button
+                      key={style.value}
+                      type="button"
+                      className={`chip ${isSelected ? 'selected' : ''}`}
+                      onClick={() => handleInterestToggle(style.value)}
+                      aria-pressed={isSelected}
+                      aria-label={`${style.label} ${isSelected ? '선택됨' : '선택 안됨'}`}
+                    >
+                      {style.icon && <span className="chip-icon">{style.icon}</span>}
+                      <span className="chip-label">{style.label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="button-group">
+              <SignupButton
+                variant="primary"
+                onClick={onBack}
+                type="button"
+                style={{ flex: 1 }}
+                aria-label="이전 단계로"
+                data-testid="back-button"
+              >
+                이전
+              </SignupButton>
+              <SignupButton
+                variant="primary"
+                onClick={handleNext}
+                disabled={!isFormValid}
+                type="button"
+                style={{ flex: 2 }}
+                aria-label="다음 단계로"
+                data-testid="next-button"
+              >
+                다음
+              </SignupButton>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <style jsx>{`
+        .step2-container {
+          display: flex;
+          justify-content: center;
+          align-items: flex-start;
+          min-height: 70vh;
+          padding: 24px;
+        }
+
+        .step2-card {
+          background: rgba(255, 255, 255, 0.95);
+          backdrop-filter: blur(20px);
+          -webkit-backdrop-filter: blur(20px);
+          border-radius: 24px;
+          padding: 48px;
+          max-width: 560px;
+          width: 100%;
+          box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+          border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+
+        .step2-header {
+          text-align: center;
+          margin-bottom: 40px;
+        }
+
+        .step2-title {
+          font-size: 28px;
+          font-weight: 800;
+          color: #1a1a1a;
+          margin: 0 0 16px 0;
+          letter-spacing: -0.5px;
+        }
+
+        .step2-description {
+          font-size: 15px;
+          color: #666;
+          line-height: 1.6;
+          margin: 0;
+        }
+
+        .step2-content {
+          display: flex;
+          flex-direction: column;
+          gap: 24px;
+        }
+
+        .field-group {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+
+        .field-label {
+          font-size: 14px;
+          font-weight: 600;
+          color: #333;
+        }
+
+        .field-label.required::after {
+          content: ' *';
+          color: #ef4444;
+        }
+
+        .optional-label {
+          font-weight: 400;
+          color: #999;
+          font-size: 13px;
+        }
+
+        .field-input,
+        .field-select,
+        .field-textarea {
+          width: 100%;
+          padding: 14px 16px;
+          border: 2px solid #e5e7eb;
+          border-radius: 12px;
+          font-size: 15px;
+          color: #1a1a1a;
+          background: white;
+          transition: all 0.2s ease;
+          font-family: inherit;
+        }
+
+        .field-input:focus,
+        .field-select:focus,
+        .field-textarea:focus {
+          outline: none;
+          border-color: #693BF2;
+          box-shadow: 0 0 0 3px rgba(105, 59, 242, 0.1);
+        }
+
+        .field-input.error,
+        .field-select.error,
+        .field-textarea.error {
+          border-color: #ef4444;
+        }
+
+        .field-textarea {
+          resize: vertical;
+          min-height: 100px;
+        }
+
+        .field-error {
+          font-size: 13px;
+          color: #ef4444;
+          font-weight: 500;
+        }
+
+        .char-counter {
+          font-size: 13px;
+          color: #999;
+          text-align: right;
+          margin-top: -4px;
+        }
+
+        .char-counter.over-limit {
+          color: #ef4444;
+          font-weight: 600;
+        }
+
+        .chip-container {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+        }
+
+        .chip {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 10px 16px;
+          border: 2px solid #e5e7eb;
+          border-radius: 24px;
+          background: white;
+          font-size: 14px;
+          font-weight: 500;
+          color: #666;
+          cursor: pointer;
+          transition: all 0.2s ease;
+        }
+
+        .chip:hover {
+          border-color: #693BF2;
+          background: rgba(105, 59, 242, 0.05);
+        }
+
+        .chip.selected {
+          border-color: #693BF2;
+          background: #693BF2;
+          color: white;
+        }
+
+        .chip-icon {
+          font-size: 16px;
+          line-height: 1;
+        }
+
+        .chip-label {
+          line-height: 1;
+        }
+
+        .button-group {
+          display: flex;
+          gap: 12px;
+          margin-top: 16px;
+        }
+
+        @media (max-width: 768px) {
+          .step2-container {
+            padding: 16px;
+          }
+
+          .step2-card {
+            padding: 32px 24px;
+            border-radius: 20px;
+          }
+
+          .step2-title {
+            font-size: 24px;
+          }
+
+          .step2-description {
+            font-size: 14px;
+          }
+
+          .step2-content {
+            gap: 20px;
+          }
+
+          .button-group {
+            flex-direction: column;
+          }
+
+          .button-group > * {
+            flex: 1 !important;
+          }
+        }
+
+        @media (max-width: 480px) {
+          .step2-card {
+            padding: 28px 20px;
+          }
+
+          .step2-title {
+            font-size: 22px;
+          }
+
+          .step2-header {
+            margin-bottom: 32px;
+          }
+
+          .chip {
+            padding: 8px 14px;
+            font-size: 13px;
+          }
+        }
+      `}</style>
+    </>
+  );
+};
+
+Step2ProfileInfo.displayName = 'Step2ProfileInfo';
+
+export default Step2ProfileInfo;

--- a/lib/constants/profile.ts
+++ b/lib/constants/profile.ts
@@ -1,0 +1,105 @@
+/**
+ * Profile-related constants for Swing Connect
+ */
+
+import type { DanceLevel } from '../types/auth';
+
+// Dance levels with display labels
+export interface DanceLevelOption {
+  value: DanceLevel;
+  label: string;
+  description: string;
+}
+
+export const DANCE_LEVELS: DanceLevelOption[] = [
+  {
+    value: 'beginner',
+    label: '초급',
+    description: '6개월 미만 또는 기본 스텝 학습 중'
+  },
+  {
+    value: 'intermediate',
+    label: '중급',
+    description: '6개월~2년 또는 사교춤 가능'
+  },
+  {
+    value: 'advanced',
+    label: '고급',
+    description: '2년 이상 또는 대회 참가 경험'
+  },
+  {
+    value: 'professional',
+    label: '전문가',
+    description: '강사 또는 전문 댄서'
+  },
+];
+
+// Korean regions/cities
+export interface RegionOption {
+  value: string;
+  label: string;
+}
+
+export const REGIONS: RegionOption[] = [
+  { value: 'seoul', label: '서울' },
+  { value: 'gyeonggi', label: '경기' },
+  { value: 'busan', label: '부산' },
+  { value: 'daegu', label: '대구' },
+  { value: 'incheon', label: '인천' },
+  { value: 'gwangju', label: '광주' },
+  { value: 'daejeon', label: '대전' },
+  { value: 'ulsan', label: '울산' },
+  { value: 'sejong', label: '세종' },
+  { value: 'gangwon', label: '강원' },
+  { value: 'chungbuk', label: '충북' },
+  { value: 'chungnam', label: '충남' },
+  { value: 'jeonbuk', label: '전북' },
+  { value: 'jeonnam', label: '전남' },
+  { value: 'gyeongbuk', label: '경북' },
+  { value: 'gyeongnam', label: '경남' },
+  { value: 'jeju', label: '제주' },
+];
+
+// Dance styles/interests
+export interface DanceStyleOption {
+  value: string;
+  label: string;
+  icon?: string;
+}
+
+export const DANCE_STYLES: DanceStyleOption[] = [
+  { value: 'lindy-hop', label: '린디합', icon: '🎷' },
+  { value: 'charleston', label: '찰스턴', icon: '🎹' },
+  { value: 'balboa', label: '발보아', icon: '🎺' },
+  { value: 'blues', label: '블루스', icon: '🎵' },
+  { value: 'solo-jazz', label: '솔로 재즈', icon: '💃' },
+  { value: 'authentic-jazz', label: '어썬틱 재즈', icon: '🕺' },
+  { value: 'shag', label: '쉐그', icon: '🎶' },
+  { value: 'boogie-woogie', label: '부기우기', icon: '🎼' },
+];
+
+// Validation constants
+export const VALIDATION = {
+  NICKNAME: {
+    MIN_LENGTH: 2,
+    MAX_LENGTH: 20,
+    PATTERN: /^[a-zA-Z0-9가-힣]{2,20}$/,
+    ERROR_MESSAGES: {
+      REQUIRED: '닉네임을 입력해주세요',
+      PATTERN: '닉네임은 2-20자의 한글, 영문, 숫자만 가능합니다',
+      MIN_LENGTH: '닉네임은 최소 2자 이상이어야 합니다',
+      MAX_LENGTH: '닉네임은 최대 20자까지 가능합니다',
+    },
+  },
+  BIO: {
+    MAX_LENGTH: 200,
+    ERROR_MESSAGES: {
+      MAX_LENGTH: '자기소개는 최대 200자까지 가능합니다',
+    },
+  },
+  LOCATION: {
+    ERROR_MESSAGES: {
+      REQUIRED: '활동 지역을 선택해주세요',
+    },
+  },
+};

--- a/lib/types/signup.ts
+++ b/lib/types/signup.ts
@@ -1,0 +1,79 @@
+/**
+ * Signup wizard type definitions for Swing Connect
+ */
+
+import type { DanceLevel, AuthProvider } from './auth';
+
+export interface SignupState {
+  // Current step in the wizard (1, 2, or 3)
+  currentStep: 1 | 2 | 3;
+
+  // Step 1: Account information (from social login)
+  accountData: {
+    provider: AuthProvider | null;
+    uid: string;
+    email: string;
+    displayName: string;
+    photoURL: string;
+  };
+
+  // Step 2: Profile information
+  profileData: {
+    nickname: string;
+    danceLevel: DanceLevel;
+    location: string;
+    bio: string;
+    interests: string[];
+  };
+
+  // Step 3: Terms agreement
+  termsData: {
+    serviceTerms: boolean;
+    privacyPolicy: boolean;
+    marketingConsent: boolean;
+  };
+
+  // Error handling
+  errors: Record<string, string>;
+
+  // Loading state
+  loading: boolean;
+}
+
+export const INITIAL_SIGNUP_STATE: SignupState = {
+  currentStep: 1,
+  accountData: {
+    provider: null,
+    uid: '',
+    email: '',
+    displayName: '',
+    photoURL: '',
+  },
+  profileData: {
+    nickname: '',
+    danceLevel: 'beginner',
+    location: '',
+    bio: '',
+    interests: [],
+  },
+  termsData: {
+    serviceTerms: false,
+    privacyPolicy: false,
+    marketingConsent: false,
+  },
+  errors: {},
+  loading: false,
+};
+
+export const SIGNUP_STORAGE_KEY = 'swing-connect-signup-progress';
+
+export interface Step {
+  number: 1 | 2 | 3;
+  label: string;
+}
+
+export const SIGNUP_STEPS: Step[] = [
+  { number: 1, label: '소셜 로그인' },
+  { number: 2, label: '프로필 정보' },
+  { number: 3, label: '약관 동의' },
+];


### PR DESCRIPTION
## Summary
Implements Issue #68 - 회원가입 Step 2 - 프로필 정보 입력 UI 구현

This PR adds the second step of the signup wizard with comprehensive profile information input.

## Changes

### New Components
- **Step2ProfileInfo** - Profile info form with validation
  - Nickname input (2-20 chars, Korean/English/numbers)
  - Dance level dropdown (4 levels)
  - Location dropdown (17 Korean regions)
  - Bio textarea (optional, 200 char limit)
  - Dance style chips (optional, multi-select, 8 styles)

### Constants & Configuration
- **lib/constants/profile.ts** - Dance levels, regions, styles, validation rules
- **lib/types/signup.ts** - SignupState interface and constants

### Features
✅ Real-time validation on blur  
✅ Character counter for bio (red when over limit)  
✅ Next button disabled until required fields valid  
✅ Previous button returns to Step 1  
✅ Dance style chips with icons for visual selection  
✅ Glassmorphism design matching app theme  
✅ Responsive mobile-first layout  
✅ Full accessibility support

### Testing
- **69 comprehensive tests** - all passing ✅
- Coverage: validation, dropdowns, chips, buttons, accessibility, responsiveness
- No new lint warnings or type errors

## Technical Highlights

### Validation
- Nickname: /^[a-zA-Z0-9가-힣]{2,20}$/ pattern
- Location: Required selection
- Bio: Optional, max 200 chars with live counter
- Form validity gates Next button state

### State Management
- Local state for form data and touched fields
- Real-time parent updates via onUpdateProfileData
- Error state per field with descriptive messages

### UX Design
- Blur-based validation (not on every keystroke)
- Visual feedback for errors and character limits
- Chip-based multi-select for interests
- Disabled state communicates form validity

## Screenshots
Profile form with nickname, level, location, bio, and dance style chips

## Testing Instructions
```bash
npm test -- Step2ProfileInfo.test.tsx
npm run type-check
npm run lint
```

## Related Issues
Closes #68

## Next Steps
- Issue #69: Step 3 - Terms agreement
- Complete signup wizard integration
- Wire up to backend API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>