### PR TITLE
feat: Implement Step3Terms with terms agreement checkboxes

### DIFF
--- a/__tests__/app/signup/components/Step3Terms.test.tsx
+++ b/__tests__/app/signup/components/Step3Terms.test.tsx
@@ -1,0 +1,758 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Step3Terms from '@/app/signup/components/Step3Terms';
+import type { Step3TermsProps } from '@/app/signup/components/Step3Terms';
+
+// Mock SignupButton component
+jest.mock('@/app/signup/components/SignupButton', () => {
+  return function MockSignupButton({
+    children,
+    onClick,
+    disabled,
+    loading,
+    variant,
+    type,
+    style,
+    'aria-label': ariaLabel,
+    'data-testid': dataTestId,
+    ...props
+  }: any) {
+    return (
+      <button
+        onClick={onClick}
+        disabled={disabled || loading}
+        data-loading={loading}
+        data-variant={variant}
+        type={type}
+        style={style}
+        aria-label={ariaLabel}
+        data-testid={dataTestId}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  };
+});
+
+// Mock SignupState type
+type MockSignupState = {
+  termsData: {
+    serviceTerms: boolean;
+    privacyPolicy: boolean;
+    marketingConsent: boolean;
+  };
+};
+
+describe('Step3Terms Component', () => {
+  // Mock functions
+  const mockOnBack = jest.fn();
+  const mockOnSubmit = jest.fn();
+  const mockOnUpdateTermsData = jest.fn();
+
+  // Default props
+  const defaultProps: Step3TermsProps = {
+    termsData: {
+      serviceTerms: false,
+      privacyPolicy: false,
+      marketingConsent: false,
+    },
+    loading: false,
+    onBack: mockOnBack,
+    onSubmit: mockOnSubmit,
+    onUpdateTermsData: mockOnUpdateTermsData,
+  };
+
+  // Mock window.open
+  const mockWindowOpen = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.open = mockWindowOpen;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('1. 초기 렌더링 - UI Elements', () => {
+    it('should render all UI elements correctly', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      // Header elements
+      expect(screen.getByText('약관 동의')).toBeInTheDocument();
+      expect(screen.getByText(/서비스 이용을 위해/)).toBeInTheDocument();
+      expect(screen.getByText(/약관에 동의해주세요/)).toBeInTheDocument();
+
+      // Agree all checkbox
+      expect(screen.getByLabelText('전체 동의')).toBeInTheDocument();
+      expect(screen.getByText('전체 동의')).toBeInTheDocument();
+
+      // Service terms checkbox
+      expect(screen.getByLabelText('서비스 이용약관 동의 (필수)')).toBeInTheDocument();
+      expect(screen.getByText('서비스 이용약관')).toBeInTheDocument();
+      const requiredIndicators = screen.getAllByText('(필수)');
+      expect(requiredIndicators.length).toBeGreaterThanOrEqual(2);
+
+      // Privacy policy checkbox
+      expect(screen.getByLabelText('개인정보 처리방침 동의 (필수)')).toBeInTheDocument();
+      expect(screen.getByText('개인정보 처리방침')).toBeInTheDocument();
+
+      // Marketing consent checkbox
+      expect(screen.getByLabelText('마케팅 정보 수신 동의 (선택)')).toBeInTheDocument();
+      expect(screen.getByText('마케팅 정보 수신 동의')).toBeInTheDocument();
+      expect(screen.getByText('(선택)')).toBeInTheDocument();
+      expect(screen.getByText(/이벤트, 프로모션 등 마케팅 정보/)).toBeInTheDocument();
+    });
+
+    it('should render all checkboxes unchecked by default', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const agreeAllCheckbox = screen.getByLabelText('전체 동의') as HTMLInputElement;
+      const serviceTermsCheckbox = screen.getByLabelText('서비스 이용약관 동의 (필수)') as HTMLInputElement;
+      const privacyPolicyCheckbox = screen.getByLabelText('개인정보 처리방침 동의 (필수)') as HTMLInputElement;
+      const marketingConsentCheckbox = screen.getByLabelText('마케팅 정보 수신 동의 (선택)') as HTMLInputElement;
+
+      expect(agreeAllCheckbox.checked).toBe(false);
+      expect(serviceTermsCheckbox.checked).toBe(false);
+      expect(privacyPolicyCheckbox.checked).toBe(false);
+      expect(marketingConsentCheckbox.checked).toBe(false);
+    });
+
+    it('should render action buttons with correct labels', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const backButton = screen.getByTestId('back-button');
+      const submitButton = screen.getByTestId('submit-button');
+
+      expect(backButton).toBeInTheDocument();
+      expect(backButton).toHaveTextContent('이전');
+      expect(backButton).toHaveAttribute('aria-label', '이전 단계로');
+
+      expect(submitButton).toBeInTheDocument();
+      expect(submitButton).toHaveTextContent('회원가입 완료');
+      expect(submitButton).toHaveAttribute('aria-label', '회원가입 완료');
+    });
+
+    it('should render "보기" links for required terms', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const viewLinks = screen.getAllByText('보기');
+      expect(viewLinks).toHaveLength(2); // Service terms and Privacy policy
+
+      expect(screen.getByLabelText('서비스 이용약관 보기')).toBeInTheDocument();
+      expect(screen.getByLabelText('개인정보 처리방침 보기')).toBeInTheDocument();
+    });
+  });
+
+  describe('2. 전체 동의 - Agree All Functionality', () => {
+    it('should check all checkboxes when agree all is checked', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const agreeAllCheckbox = screen.getByLabelText('전체 동의');
+
+      await userEvent.click(agreeAllCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledWith({
+        serviceTerms: true,
+        privacyPolicy: true,
+        marketingConsent: true,
+      });
+    });
+
+    it('should uncheck all checkboxes when agree all is unchecked', async () => {
+      const propsWithAllChecked: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: true,
+        },
+      };
+
+      render(<Step3Terms {...propsWithAllChecked} />);
+
+      const agreeAllCheckbox = screen.getByLabelText('전체 동의') as HTMLInputElement;
+      expect(agreeAllCheckbox.checked).toBe(true);
+
+      await userEvent.click(agreeAllCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledWith({
+        serviceTerms: false,
+        privacyPolicy: false,
+        marketingConsent: false,
+      });
+    });
+
+    it('should check agree all when all individual checkboxes are checked', () => {
+      const propsWithAllChecked: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: true,
+        },
+      };
+
+      render(<Step3Terms {...propsWithAllChecked} />);
+
+      const agreeAllCheckbox = screen.getByLabelText('전체 동의') as HTMLInputElement;
+      expect(agreeAllCheckbox.checked).toBe(true);
+    });
+
+    it('should uncheck agree all when any individual checkbox is unchecked', () => {
+      const propsWithPartialCheck: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: false,
+        },
+      };
+
+      render(<Step3Terms {...propsWithPartialCheck} />);
+
+      const agreeAllCheckbox = screen.getByLabelText('전체 동의') as HTMLInputElement;
+      expect(agreeAllCheckbox.checked).toBe(false);
+    });
+  });
+
+  describe('3. 개별 약관 동의 - Individual Checkbox Changes', () => {
+    it('should toggle service terms checkbox', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const serviceTermsCheckbox = screen.getByLabelText('서비스 이용약관 동의 (필수)');
+
+      await userEvent.click(serviceTermsCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledWith({
+        serviceTerms: true,
+      });
+    });
+
+    it('should toggle privacy policy checkbox', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const privacyPolicyCheckbox = screen.getByLabelText('개인정보 처리방침 동의 (필수)');
+
+      await userEvent.click(privacyPolicyCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledWith({
+        privacyPolicy: true,
+      });
+    });
+
+    it('should toggle marketing consent checkbox', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const marketingConsentCheckbox = screen.getByLabelText('마케팅 정보 수신 동의 (선택)');
+
+      await userEvent.click(marketingConsentCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledWith({
+        marketingConsent: true,
+      });
+    });
+
+    it('should update local state and parent state on individual checkbox change', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const serviceTermsCheckbox = screen.getByLabelText('서비스 이용약관 동의 (필수)') as HTMLInputElement;
+
+      expect(serviceTermsCheckbox.checked).toBe(false);
+
+      await userEvent.click(serviceTermsCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledTimes(1);
+      expect(mockOnUpdateTermsData).toHaveBeenCalledWith({
+        serviceTerms: true,
+      });
+    });
+  });
+
+  describe('4. 필수 약관 검증 - Submit Button Validation', () => {
+    it('should disable submit button when required terms are not agreed', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+      expect(submitButton).toBeDisabled();
+    });
+
+    it('should disable submit button when only service terms is agreed', () => {
+      const propsWithServiceTerms: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: false,
+          marketingConsent: false,
+        },
+      };
+
+      render(<Step3Terms {...propsWithServiceTerms} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+      expect(submitButton).toBeDisabled();
+    });
+
+    it('should disable submit button when only privacy policy is agreed', () => {
+      const propsWithPrivacyPolicy: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: false,
+          privacyPolicy: true,
+          marketingConsent: false,
+        },
+      };
+
+      render(<Step3Terms {...propsWithPrivacyPolicy} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+      expect(submitButton).toBeDisabled();
+    });
+
+    it('should enable submit button when all required terms are agreed', () => {
+      const propsWithRequiredTerms: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: false,
+        },
+      };
+
+      render(<Step3Terms {...propsWithRequiredTerms} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    it('should enable submit button when all terms including optional are agreed', () => {
+      const propsWithAllTerms: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: true,
+        },
+      };
+
+      render(<Step3Terms {...propsWithAllTerms} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+
+  describe('5. 보기 링크 - View Terms Links', () => {
+    it('should open service terms in new window when 보기 link is clicked', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const serviceTermsViewLink = screen.getByLabelText('서비스 이용약관 보기');
+
+      await userEvent.click(serviceTermsViewLink);
+
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        '/terms/service',
+        '_blank',
+        'noopener,noreferrer'
+      );
+    });
+
+    it('should open privacy policy in new window when 보기 link is clicked', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const privacyPolicyViewLink = screen.getByLabelText('개인정보 처리방침 보기');
+
+      await userEvent.click(privacyPolicyViewLink);
+
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        '/terms/privacy',
+        '_blank',
+        'noopener,noreferrer'
+      );
+    });
+
+    it('should have correct type attribute for view links', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const serviceTermsViewLink = screen.getByLabelText('서비스 이용약관 보기');
+      const privacyPolicyViewLink = screen.getByLabelText('개인정보 처리방침 보기');
+
+      expect(serviceTermsViewLink).toHaveAttribute('type', 'button');
+      expect(privacyPolicyViewLink).toHaveAttribute('type', 'button');
+    });
+  });
+
+  describe('6. 버튼 동작 - Button Actions', () => {
+    it('should call onBack when back button is clicked', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const backButton = screen.getByTestId('back-button');
+
+      await userEvent.click(backButton);
+
+      expect(mockOnBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onSubmit when submit button is clicked and required terms are agreed', async () => {
+      const propsWithRequiredTerms: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: false,
+        },
+      };
+
+      render(<Step3Terms {...propsWithRequiredTerms} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+
+      await userEvent.click(submitButton);
+
+      expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call onSubmit when submit button is clicked and required terms are not agreed', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+
+      // Try to click disabled button
+      fireEvent.click(submitButton);
+
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should disable back button during loading', () => {
+      const propsWithLoading: Step3TermsProps = {
+        ...defaultProps,
+        loading: true,
+      };
+
+      render(<Step3Terms {...propsWithLoading} />);
+
+      const backButton = screen.getByTestId('back-button');
+      expect(backButton).toBeDisabled();
+    });
+  });
+
+  describe('7. 로딩 상태 - Loading State', () => {
+    it('should show loading text when loading prop is true', () => {
+      const propsWithLoading: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: false,
+        },
+        loading: true,
+      };
+
+      render(<Step3Terms {...propsWithLoading} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+      expect(submitButton).toHaveTextContent('처리 중...');
+    });
+
+    it('should show normal text when loading prop is false', () => {
+      const propsWithRequiredTerms: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: false,
+        },
+        loading: false,
+      };
+
+      render(<Step3Terms {...propsWithRequiredTerms} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+      expect(submitButton).toHaveTextContent('회원가입 완료');
+    });
+
+    it('should disable submit button during loading even if required terms are agreed', () => {
+      const propsWithLoadingAndTerms: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: false,
+        },
+        loading: true,
+      };
+
+      render(<Step3Terms {...propsWithLoadingAndTerms} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+      expect(submitButton).toBeDisabled();
+    });
+
+    it('should pass loading prop to SignupButton component', () => {
+      const propsWithLoading: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: false,
+        },
+        loading: true,
+      };
+
+      render(<Step3Terms {...propsWithLoading} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+      expect(submitButton).toHaveAttribute('data-loading', 'true');
+    });
+
+    it('should not call onSubmit when loading is true', async () => {
+      const propsWithLoading: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: false,
+        },
+        loading: true,
+      };
+
+      render(<Step3Terms {...propsWithLoading} />);
+
+      const submitButton = screen.getByTestId('submit-button');
+
+      // Try to click disabled button
+      fireEvent.click(submitButton);
+
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('8. 접근성 - Accessibility', () => {
+    it('should have proper ARIA labels for all checkboxes', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      expect(screen.getByLabelText('전체 동의')).toBeInTheDocument();
+      expect(screen.getByLabelText('서비스 이용약관 동의 (필수)')).toBeInTheDocument();
+      expect(screen.getByLabelText('개인정보 처리방침 동의 (필수)')).toBeInTheDocument();
+      expect(screen.getByLabelText('마케팅 정보 수신 동의 (선택)')).toBeInTheDocument();
+    });
+
+    it('should mark required checkboxes with aria-required', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const serviceTermsCheckbox = screen.getByLabelText('서비스 이용약관 동의 (필수)');
+      const privacyPolicyCheckbox = screen.getByLabelText('개인정보 처리방침 동의 (필수)');
+      const marketingConsentCheckbox = screen.getByLabelText('마케팅 정보 수신 동의 (선택)');
+
+      expect(serviceTermsCheckbox).toHaveAttribute('aria-required', 'true');
+      expect(privacyPolicyCheckbox).toHaveAttribute('aria-required', 'true');
+      expect(marketingConsentCheckbox).not.toHaveAttribute('aria-required');
+    });
+
+    it('should have proper ARIA labels for action buttons', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const backButton = screen.getByTestId('back-button');
+      const submitButton = screen.getByTestId('submit-button');
+
+      expect(backButton).toHaveAttribute('aria-label', '이전 단계로');
+      expect(submitButton).toHaveAttribute('aria-label', '회원가입 완료');
+    });
+
+    it('should have proper ARIA labels for view links', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      expect(screen.getByLabelText('서비스 이용약관 보기')).toBeInTheDocument();
+      expect(screen.getByLabelText('개인정보 처리방침 보기')).toBeInTheDocument();
+    });
+
+    it('should hide custom checkbox from screen readers with aria-hidden', () => {
+      const { container } = render(<Step3Terms {...defaultProps} />);
+
+      const customCheckboxes = container.querySelectorAll('.checkbox-custom');
+      customCheckboxes.forEach(checkbox => {
+        expect(checkbox).toHaveAttribute('aria-hidden', 'true');
+      });
+    });
+  });
+
+  describe('9. 데이터 동기화 - Data Synchronization', () => {
+    it('should sync with parent when termsData prop changes', () => {
+      const { rerender } = render(<Step3Terms {...defaultProps} />);
+
+      const serviceTermsCheckbox = screen.getByLabelText('서비스 이용약관 동의 (필수)') as HTMLInputElement;
+      expect(serviceTermsCheckbox.checked).toBe(false);
+
+      // Update props
+      const updatedProps: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: false,
+          marketingConsent: false,
+        },
+      };
+
+      rerender(<Step3Terms {...updatedProps} />);
+
+      expect(serviceTermsCheckbox.checked).toBe(true);
+    });
+
+    it('should update parent state via onUpdateTermsData on checkbox changes', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const serviceTermsCheckbox = screen.getByLabelText('서비스 이용약관 동의 (필수)');
+
+      await userEvent.click(serviceTermsCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledWith({
+        serviceTerms: true,
+      });
+
+      const privacyPolicyCheckbox = screen.getByLabelText('개인정보 처리방침 동의 (필수)');
+
+      await userEvent.click(privacyPolicyCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledWith({
+        privacyPolicy: true,
+      });
+    });
+
+    it('should maintain local state independently from parent', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const serviceTermsCheckbox = screen.getByLabelText('서비스 이용약관 동의 (필수)');
+
+      await userEvent.click(serviceTermsCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledWith({
+        serviceTerms: true,
+      });
+
+      // Parent hasn't updated yet, but local state should reflect the change
+      // This is tested implicitly by the component continuing to function correctly
+    });
+
+    it('should handle rapid checkbox changes', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const serviceTermsCheckbox = screen.getByLabelText('서비스 이용약관 동의 (필수)');
+      const privacyPolicyCheckbox = screen.getByLabelText('개인정보 처리방침 동의 (필수)');
+
+      await userEvent.click(serviceTermsCheckbox);
+      await userEvent.click(privacyPolicyCheckbox);
+      await userEvent.click(serviceTermsCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledTimes(3);
+      expect(mockOnUpdateTermsData).toHaveBeenNthCalledWith(1, { serviceTerms: true });
+      expect(mockOnUpdateTermsData).toHaveBeenNthCalledWith(2, { privacyPolicy: true });
+      expect(mockOnUpdateTermsData).toHaveBeenNthCalledWith(3, { serviceTerms: false });
+    });
+
+    it('should sync all checkboxes when termsData updates from parent', () => {
+      const { rerender } = render(<Step3Terms {...defaultProps} />);
+
+      const agreeAllCheckbox = screen.getByLabelText('전체 동의') as HTMLInputElement;
+      const serviceTermsCheckbox = screen.getByLabelText('서비스 이용약관 동의 (필수)') as HTMLInputElement;
+      const privacyPolicyCheckbox = screen.getByLabelText('개인정보 처리방침 동의 (필수)') as HTMLInputElement;
+      const marketingConsentCheckbox = screen.getByLabelText('마케팅 정보 수신 동의 (선택)') as HTMLInputElement;
+
+      expect(agreeAllCheckbox.checked).toBe(false);
+      expect(serviceTermsCheckbox.checked).toBe(false);
+      expect(privacyPolicyCheckbox.checked).toBe(false);
+      expect(marketingConsentCheckbox.checked).toBe(false);
+
+      // Update all terms from parent
+      const updatedProps: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: true,
+        },
+      };
+
+      rerender(<Step3Terms {...updatedProps} />);
+
+      expect(agreeAllCheckbox.checked).toBe(true);
+      expect(serviceTermsCheckbox.checked).toBe(true);
+      expect(privacyPolicyCheckbox.checked).toBe(true);
+      expect(marketingConsentCheckbox.checked).toBe(true);
+    });
+  });
+
+  describe('Edge Cases and Integration', () => {
+    it('should handle checkbox interaction correctly', async () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const agreeAllCheckbox = screen.getByLabelText('전체 동의');
+
+      await userEvent.click(agreeAllCheckbox);
+
+      expect(mockOnUpdateTermsData).toHaveBeenCalledWith({
+        serviceTerms: true,
+        privacyPolicy: true,
+        marketingConsent: true,
+      });
+    });
+
+    it('should display correct required/optional indicators', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const requiredIndicators = screen.getAllByText('(필수)');
+      const optionalIndicator = screen.getByText('(선택)');
+
+      expect(requiredIndicators).toHaveLength(2); // Service terms and Privacy policy
+      expect(optionalIndicator).toBeInTheDocument();
+    });
+
+    it('should have correct button styles and variants', () => {
+      render(<Step3Terms {...defaultProps} />);
+
+      const backButton = screen.getByTestId('back-button');
+      const submitButton = screen.getByTestId('submit-button');
+
+      expect(backButton).toHaveAttribute('data-variant', 'primary');
+      expect(submitButton).toHaveAttribute('data-variant', 'primary');
+      expect(backButton).toHaveAttribute('type', 'button');
+      expect(submitButton).toHaveAttribute('type', 'button');
+    });
+
+    it('should maintain checkbox state consistency during rapid updates', async () => {
+      const { rerender } = render(<Step3Terms {...defaultProps} />);
+
+      const agreeAllCheckbox = screen.getByLabelText('전체 동의');
+
+      await userEvent.click(agreeAllCheckbox);
+
+      // Simulate parent updating state
+      const updatedProps1: Step3TermsProps = {
+        ...defaultProps,
+        termsData: {
+          serviceTerms: true,
+          privacyPolicy: true,
+          marketingConsent: true,
+        },
+      };
+
+      rerender(<Step3Terms {...updatedProps1} />);
+
+      const allCheckboxes = [
+        screen.getByLabelText('전체 동의'),
+        screen.getByLabelText('서비스 이용약관 동의 (필수)'),
+        screen.getByLabelText('개인정보 처리방침 동의 (필수)'),
+        screen.getByLabelText('마케팅 정보 수신 동의 (선택)'),
+      ] as HTMLInputElement[];
+
+      allCheckboxes.forEach(checkbox => {
+        expect(checkbox.checked).toBe(true);
+      });
+    });
+  });
+});

--- a/app/signup/components/SignupButton.tsx
+++ b/app/signup/components/SignupButton.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+
+export interface SignupButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+  loading?: boolean;
+  children: React.ReactNode;
+}
+
+const SignupButton: React.FC<SignupButtonProps> = ({
+  variant = 'primary',
+  loading = false,
+  children,
+  disabled,
+  className = '',
+  ...props
+}) => {
+  return (
+    <button
+      className={`signup-button ${variant} ${className}`}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {children}
+      <style jsx>{`
+        .signup-button {
+          padding: 14px 28px;
+          border-radius: 12px;
+          font-size: 15px;
+          font-weight: 600;
+          border: none;
+          cursor: pointer;
+          transition: all 0.2s ease;
+        }
+
+        .signup-button.primary {
+          background: #693BF2;
+          color: white;
+        }
+
+        .signup-button.primary:hover:not(:disabled) {
+          background: #5729d1;
+        }
+
+        .signup-button.secondary {
+          background: #f3f4f6;
+          color: #1a1a1a;
+        }
+
+        .signup-button.secondary:hover:not(:disabled) {
+          background: #e5e7eb;
+        }
+
+        .signup-button:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+      `}</style>
+    </button>
+  );
+};
+
+SignupButton.displayName = 'SignupButton';
+
+export default SignupButton;

--- a/app/signup/components/Step3Terms.tsx
+++ b/app/signup/components/Step3Terms.tsx
@@ -1,0 +1,456 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import SignupButton from './SignupButton';
+import type { SignupState } from '@/lib/types/signup';
+
+export interface Step3TermsProps {
+  termsData: SignupState['termsData'];
+  loading: boolean;
+  onBack: () => void;
+  onSubmit: () => void;
+  onUpdateTermsData: (data: Partial<SignupState['termsData']>) => void;
+}
+
+const Step3Terms: React.FC<Step3TermsProps> = ({
+  termsData,
+  loading,
+  onBack,
+  onSubmit,
+  onUpdateTermsData,
+}) => {
+  const [localData, setLocalData] = useState(termsData);
+
+  // Sync with parent when termsData changes
+  useEffect(() => {
+    setLocalData(termsData);
+  }, [termsData]);
+
+  // Check if all terms are agreed (for "agree all" checkbox)
+  const allAgreed =
+    localData.serviceTerms && localData.privacyPolicy && localData.marketingConsent;
+
+  // Check if required terms are agreed (for submit button)
+  const requiredAgreed = localData.serviceTerms && localData.privacyPolicy;
+
+  const handleTermChange = (term: keyof SignupState['termsData'], value: boolean) => {
+    const newData = { ...localData, [term]: value };
+    setLocalData(newData);
+    onUpdateTermsData({ [term]: value });
+  };
+
+  const handleAgreeAll = () => {
+    const newValue = !allAgreed;
+    const newData = {
+      serviceTerms: newValue,
+      privacyPolicy: newValue,
+      marketingConsent: newValue,
+    };
+    setLocalData(newData);
+    onUpdateTermsData(newData);
+  };
+
+  const handleSubmit = () => {
+    if (requiredAgreed && !loading) {
+      onSubmit();
+    }
+  };
+
+  const handleViewTerms = (type: 'service' | 'privacy') => {
+    const url = type === 'service' ? '/terms/service' : '/terms/privacy';
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <>
+      <div className="step3-container">
+        <div className="step3-card">
+          <div className="step3-header">
+            <h2 className="step3-title">약관 동의</h2>
+            <p className="step3-description">
+              서비스 이용을 위해<br />
+              약관에 동의해주세요
+            </p>
+          </div>
+
+          <div className="step3-content">
+            {/* Agree All Checkbox */}
+            <div className="checkbox-item all">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  className="checkbox-input"
+                  checked={allAgreed}
+                  onChange={handleAgreeAll}
+                  aria-label="전체 동의"
+                />
+                <span className="checkbox-custom" aria-hidden="true">
+                  {allAgreed && <span className="checkmark">✓</span>}
+                </span>
+                <span className="checkbox-text">전체 동의</span>
+              </label>
+            </div>
+
+            <div className="divider" />
+
+            {/* Service Terms (Required) */}
+            <div className="checkbox-item">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  className="checkbox-input"
+                  checked={localData.serviceTerms}
+                  onChange={(e) => handleTermChange('serviceTerms', e.target.checked)}
+                  aria-label="서비스 이용약관 동의 (필수)"
+                  aria-required="true"
+                />
+                <span className="checkbox-custom" aria-hidden="true">
+                  {localData.serviceTerms && <span className="checkmark">✓</span>}
+                </span>
+                <span className="checkbox-text">
+                  <span className="term-title">
+                    서비스 이용약관 <span className="required">(필수)</span>
+                  </span>
+                </span>
+              </label>
+              <button
+                type="button"
+                className="view-link"
+                onClick={() => handleViewTerms('service')}
+                aria-label="서비스 이용약관 보기"
+              >
+                보기
+              </button>
+            </div>
+
+            {/* Privacy Policy (Required) */}
+            <div className="checkbox-item">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  className="checkbox-input"
+                  checked={localData.privacyPolicy}
+                  onChange={(e) => handleTermChange('privacyPolicy', e.target.checked)}
+                  aria-label="개인정보 처리방침 동의 (필수)"
+                  aria-required="true"
+                />
+                <span className="checkbox-custom" aria-hidden="true">
+                  {localData.privacyPolicy && <span className="checkmark">✓</span>}
+                </span>
+                <span className="checkbox-text">
+                  <span className="term-title">
+                    개인정보 처리방침 <span className="required">(필수)</span>
+                  </span>
+                </span>
+              </label>
+              <button
+                type="button"
+                className="view-link"
+                onClick={() => handleViewTerms('privacy')}
+                aria-label="개인정보 처리방침 보기"
+              >
+                보기
+              </button>
+            </div>
+
+            {/* Marketing Consent (Optional) */}
+            <div className="checkbox-item">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  className="checkbox-input"
+                  checked={localData.marketingConsent}
+                  onChange={(e) => handleTermChange('marketingConsent', e.target.checked)}
+                  aria-label="마케팅 정보 수신 동의 (선택)"
+                />
+                <span className="checkbox-custom" aria-hidden="true">
+                  {localData.marketingConsent && <span className="checkmark">✓</span>}
+                </span>
+                <span className="checkbox-text">
+                  <span className="term-title">마케팅 정보 수신 동의 <span className="optional">(선택)</span></span>
+                  <span className="term-description">
+                    이벤트, 프로모션 등 마케팅 정보를 이메일로 받아보실 수 있습니다.
+                  </span>
+                </span>
+              </label>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="button-group">
+              <SignupButton
+                variant="primary"
+                onClick={onBack}
+                disabled={loading}
+                type="button"
+                style={{ flex: 1 }}
+                aria-label="이전 단계로"
+                data-testid="back-button"
+              >
+                이전
+              </SignupButton>
+              <SignupButton
+                variant="primary"
+                onClick={handleSubmit}
+                disabled={!requiredAgreed || loading}
+                loading={loading}
+                type="button"
+                style={{ flex: 2 }}
+                aria-label="회원가입 완료"
+                data-testid="submit-button"
+              >
+                {loading ? '처리 중...' : '회원가입 완료'}
+              </SignupButton>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <style jsx>{`
+        .step3-container {
+          display: flex;
+          justify-content: center;
+          align-items: flex-start;
+          min-height: 70vh;
+          padding: 24px;
+        }
+
+        .step3-card {
+          background: rgba(255, 255, 255, 0.95);
+          backdrop-filter: blur(20px);
+          -webkit-backdrop-filter: blur(20px);
+          border-radius: 24px;
+          padding: 48px;
+          max-width: 560px;
+          width: 100%;
+          box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+          border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+
+        .step3-header {
+          text-align: center;
+          margin-bottom: 40px;
+        }
+
+        .step3-title {
+          font-size: 28px;
+          font-weight: 800;
+          color: #1a1a1a;
+          margin: 0 0 16px 0;
+          letter-spacing: -0.5px;
+        }
+
+        .step3-description {
+          font-size: 15px;
+          color: #666;
+          line-height: 1.6;
+          margin: 0;
+        }
+
+        .step3-content {
+          display: flex;
+          flex-direction: column;
+          gap: 20px;
+        }
+
+        .checkbox-item {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          padding: 16px;
+          border-radius: 12px;
+          transition: background-color 0.2s ease;
+        }
+
+        .checkbox-item:hover {
+          background: rgba(105, 59, 242, 0.03);
+        }
+
+        .checkbox-item.all {
+          background: linear-gradient(135deg, rgba(102, 126, 234, 0.08) 0%, rgba(118, 75, 162, 0.08) 100%);
+          border: 2px solid rgba(105, 59, 242, 0.2);
+          padding: 20px;
+          font-weight: 600;
+        }
+
+        .checkbox-label {
+          display: flex;
+          align-items: flex-start;
+          gap: 12px;
+          cursor: pointer;
+          flex: 1;
+        }
+
+        .checkbox-input {
+          position: absolute;
+          opacity: 0;
+          width: 0;
+          height: 0;
+        }
+
+        .checkbox-custom {
+          position: relative;
+          width: 24px;
+          height: 24px;
+          border: 2px solid #d1d5db;
+          border-radius: 6px;
+          background: white;
+          transition: all 0.2s ease;
+          flex-shrink: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        .checkbox-input:checked + .checkbox-custom {
+          background: #693BF2;
+          border-color: #693BF2;
+        }
+
+        .checkbox-input:focus + .checkbox-custom {
+          outline: 2px solid #693BF2;
+          outline-offset: 2px;
+        }
+
+        .checkmark {
+          color: white;
+          font-size: 16px;
+          font-weight: bold;
+          line-height: 1;
+        }
+
+        .checkbox-text {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          flex: 1;
+        }
+
+        .term-title {
+          font-size: 15px;
+          color: #1a1a1a;
+          font-weight: 500;
+        }
+
+        .term-description {
+          font-size: 13px;
+          color: #666;
+          line-height: 1.5;
+        }
+
+        .required {
+          color: #ef4444;
+          font-weight: 600;
+        }
+
+        .optional {
+          color: #999;
+          font-weight: 400;
+        }
+
+        .view-link {
+          font-size: 14px;
+          color: #693BF2;
+          background: none;
+          border: none;
+          cursor: pointer;
+          text-decoration: underline;
+          padding: 0 8px;
+          flex-shrink: 0;
+          transition: color 0.2s ease;
+        }
+
+        .view-link:hover {
+          color: #5729d1;
+        }
+
+        .view-link:focus {
+          outline: 2px solid #693BF2;
+          outline-offset: 2px;
+          border-radius: 4px;
+        }
+
+        .divider {
+          height: 1px;
+          background: linear-gradient(
+            to right,
+            transparent,
+            rgba(0, 0, 0, 0.1),
+            transparent
+          );
+          margin: 8px 0;
+        }
+
+        .button-group {
+          display: flex;
+          gap: 12px;
+          margin-top: 16px;
+        }
+
+        @media (max-width: 768px) {
+          .step3-container {
+            padding: 16px;
+          }
+
+          .step3-card {
+            padding: 32px 24px;
+            border-radius: 20px;
+          }
+
+          .step3-title {
+            font-size: 24px;
+          }
+
+          .step3-description {
+            font-size: 14px;
+          }
+
+          .step3-content {
+            gap: 16px;
+          }
+
+          .checkbox-item {
+            padding: 12px;
+          }
+
+          .checkbox-item.all {
+            padding: 16px;
+          }
+
+          .button-group {
+            flex-direction: column;
+          }
+
+          .button-group > * {
+            flex: 1 !important;
+          }
+        }
+
+        @media (max-width: 480px) {
+          .step3-card {
+            padding: 28px 20px;
+          }
+
+          .step3-title {
+            font-size: 22px;
+          }
+
+          .step3-header {
+            margin-bottom: 32px;
+          }
+
+          .term-title {
+            font-size: 14px;
+          }
+
+          .term-description {
+            font-size: 12px;
+          }
+        }
+      `}</style>
+    </>
+  );
+};
+
+Step3Terms.displayName = 'Step3Terms';
+
+export default Step3Terms;

--- a/lib/types/signup.ts
+++ b/lib/types/signup.ts
@@ -1,0 +1,79 @@
+/**
+ * Signup wizard type definitions for Swing Connect
+ */
+
+import type { DanceLevel, AuthProvider } from './auth';
+
+export interface SignupState {
+  // Current step in the wizard (1, 2, or 3)
+  currentStep: 1 | 2 | 3;
+
+  // Step 1: Account information (from social login)
+  accountData: {
+    provider: AuthProvider | null;
+    uid: string;
+    email: string;
+    displayName: string;
+    photoURL: string;
+  };
+
+  // Step 2: Profile information
+  profileData: {
+    nickname: string;
+    danceLevel: DanceLevel;
+    location: string;
+    bio: string;
+    interests: string[];
+  };
+
+  // Step 3: Terms agreement
+  termsData: {
+    serviceTerms: boolean;
+    privacyPolicy: boolean;
+    marketingConsent: boolean;
+  };
+
+  // Error handling
+  errors: Record<string, string>;
+
+  // Loading state
+  loading: boolean;
+}
+
+export const INITIAL_SIGNUP_STATE: SignupState = {
+  currentStep: 1,
+  accountData: {
+    provider: null,
+    uid: '',
+    email: '',
+    displayName: '',
+    photoURL: '',
+  },
+  profileData: {
+    nickname: '',
+    danceLevel: 'beginner',
+    location: '',
+    bio: '',
+    interests: [],
+  },
+  termsData: {
+    serviceTerms: false,
+    privacyPolicy: false,
+    marketingConsent: false,
+  },
+  errors: {},
+  loading: false,
+};
+
+export const SIGNUP_STORAGE_KEY = 'swing-connect-signup-progress';
+
+export interface Step {
+  number: 1 | 2 | 3;
+  label: string;
+}
+
+export const SIGNUP_STEPS: Step[] = [
+  { number: 1, label: '소셜 로그인' },
+  { number: 2, label: '프로필 정보' },
+  { number: 3, label: '약관 동의' },
+];


### PR DESCRIPTION
## Summary
Implements Issue #69 - 회원가입 Step 3 - 약관 동의 UI 구현

This PR adds the final step of the signup wizard with comprehensive terms agreement functionality.

## Changes

### New Components
- **Step3Terms** - Terms agreement form with custom checkboxes
  - "전체 동의" checkbox (agree all functionality)
  - 서비스 이용약관 (required) + view link
  - 개인정보 처리방침 (required) + view link
  - 마케팅 정보 수신 동의 (optional) + description
  - Custom purple checkbox design (24px)
  - Loading state during submission

### Supporting Components
- **SignupButton** - Simplified button component with loading support
- **lib/types/signup.ts** - SignupState with termsData interface

### Features
✅ Agree all checkbox - one-click toggle for all terms  
✅ Individual checkboxes with proper validation  
✅ Required terms check (serviceTerms && privacyPolicy)  
✅ Submit button disabled until required terms agreed  
✅ View links open /terms/service and /terms/privacy in new window  
✅ Loading state with "처리 중..." text  
✅ Custom checkbox design (purple #693BF2 checkmarks)  
✅ Glassmorphism styling matching app theme  
✅ Responsive mobile-first layout  
✅ Full accessibility support

### Testing
- **43 comprehensive tests** - all passing ✅
- Coverage: rendering, agree all, individual checkboxes, validation, links, buttons, loading, accessibility, data sync
- No new lint warnings or type errors

## Technical Highlights

### Checkbox Logic
- **Agree All**: Toggles all 3 checkboxes simultaneously
- **Individual Changes**: Any unchecked box unchecks "agree all"
- **Required Validation**: Submit enabled only when both required terms agreed
- **Optional Marketing**: Doesn't affect submit button state

### State Management
- Local state with parent sync via onUpdateTermsData
- Efficient updates for individual and bulk changes
- Loading state prevents duplicate submissions

### Accessibility
- ARIA labels for all interactive elements
- aria-required="true" for required checkboxes
- aria-hidden="true" for custom checkbox visuals
- Descriptive aria-label for view links
- Clear focus states with outline

### UX Design
- Custom 24px checkboxes with white checkmark on purple
- "전체 동의" section highlighted with gradient background
- Required (red) vs Optional (gray) indicators
- Loading feedback during submission
- View links open safely in new window

## Screenshots
Terms agreement form with agree all, individual checkboxes, and action buttons

## Testing Instructions
```bash
npm test -- Step3Terms.test.tsx
npm run type-check
npm run lint
```

## Related Issues
Closes #69

## Signup Wizard Completion
This completes the 3-step signup wizard:
- ✅ Step 1: Social login (Issue #67)
- ✅ Step 2: Profile information (Issue #68)
- ✅ Step 3: Terms agreement (Issue #69)

Next: Integration with SignupWizard container and backend API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>