### PR TITLE
feat: 회원가입 메인 페이지 및 기존 시스템 통합

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -156,6 +156,26 @@ function LoginContent() {
               <span className="footer-divider">|</span>
               <a href="/privacy" className="footer-link">개인정보처리방침</a>
             </div>
+
+            {/* 회원가입 링크 */}
+            <p style={{
+              marginTop: '24px',
+              textAlign: 'center',
+              fontSize: '14px',
+              color: '#9ca3af'
+            }}>
+              아직 계정이 없으신가요?{' '}
+              <a
+                href="/signup"
+                style={{
+                  color: '#667eea',
+                  textDecoration: 'none',
+                  fontWeight: 600
+                }}
+              >
+                회원가입
+              </a>
+            </p>
           </div>
         </div>
       </div>

--- a/app/signup/components/SignupButton.tsx
+++ b/app/signup/components/SignupButton.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import React from 'react';
+
+export interface SignupButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant: 'primary' | 'social-google';
+  loading?: boolean;
+  children: React.ReactNode;
+}
+
+const SignupButton = React.memo<SignupButtonProps>(
+  ({ variant, loading = false, disabled, children, className = '', ...props }) => {
+    const getVariantStyles = () => {
+      const baseStyles = `
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        width: 100%;
+        height: 56px;
+        border: none;
+        border-radius: 14px;
+        font-size: 16px;
+        font-weight: 700;
+        cursor: ${disabled || loading ? 'not-allowed' : 'pointer'};
+        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        position: relative;
+        overflow: hidden;
+        opacity: ${disabled || loading ? 0.6 : 1};
+      `;
+
+      const variantMap = {
+        'primary': `
+          ${baseStyles}
+          background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+          color: white;
+          box-shadow: 0 4px 16px rgba(102, 126, 234, 0.3);
+        `,
+        'social-google': `
+          ${baseStyles}
+          background: linear-gradient(135deg, #4285f4 0%, #357ae8 100%);
+          color: white;
+          box-shadow: 0 4px 16px rgba(66, 133, 244, 0.3);
+        `,
+      };
+
+      return variantMap[variant];
+    };
+
+    const getHoverStyles = () => {
+      const hoverMap = {
+        'primary': 'box-shadow: 0 8px 24px rgba(102, 126, 234, 0.5);',
+        'social-google': 'box-shadow: 0 8px 24px rgba(66, 133, 244, 0.5);',
+      };
+
+      return hoverMap[variant];
+    };
+
+    const getIcon = () => {
+      if (loading) {
+        return <span className="spinner">⏳</span>;
+      }
+
+      const iconMap = {
+        'primary': null,
+        'social-google': '🔵',
+      };
+
+      const icon = iconMap[variant];
+      return icon ? <span style={{ fontSize: '24px' }}>{icon}</span> : null;
+    };
+
+    return (
+      <>
+        <button
+          className={`signup-button ${className}`}
+          disabled={disabled || loading}
+          aria-busy={loading}
+          aria-label={loading ? '로딩 중...' : props['aria-label']}
+          {...props}
+        >
+          {getIcon()}
+          <span>{loading ? '로딩 중...' : children}</span>
+        </button>
+
+        <style jsx>{`
+          .signup-button {
+            ${getVariantStyles()}
+          }
+
+          .signup-button::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: -100%;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent);
+            transition: left 0.5s;
+          }
+
+          .signup-button:hover::before {
+            left: 100%;
+          }
+
+          .signup-button:not(:disabled):hover {
+            transform: translateY(-3px) scale(1.02);
+            ${getHoverStyles()}
+          }
+
+          .signup-button:not(:disabled):active {
+            transform: translateY(-1px) scale(0.98);
+          }
+
+          .signup-button:focus-visible {
+            outline: none;
+            ring: 2px solid #693BF2;
+            ring-offset: 2px;
+          }
+
+          .spinner {
+            display: inline-block;
+            animation: spin 1s linear infinite;
+          }
+
+          @keyframes spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+          }
+
+          @media (max-width: 768px) {
+            .signup-button {
+              height: 52px;
+              font-size: 15px;
+            }
+          }
+        `}</style>
+      </>
+    );
+  }
+);
+
+SignupButton.displayName = 'SignupButton';
+
+export default SignupButton;

--- a/app/signup/components/SignupWizard.tsx
+++ b/app/signup/components/SignupWizard.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import StepIndicator from './StepIndicator';
+import Step1AccountInfo from './Step1AccountInfo';
+import Step2ProfileInfo from './Step2ProfileInfo';
+import Step3Terms from './Step3Terms';
+import type { SignupState } from '@/lib/types/signup';
+import { INITIAL_SIGNUP_STATE, SIGNUP_STORAGE_KEY, SIGNUP_STEPS } from '@/lib/types/signup';
+import { doc, setDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+
+export default function SignupWizard() {
+  const router = useRouter();
+  const [state, setState] = useState<SignupState>(INITIAL_SIGNUP_STATE);
+
+  // Load saved state from localStorage on mount
+  useEffect(() => {
+    try {
+      const savedState = localStorage.getItem(SIGNUP_STORAGE_KEY);
+      if (savedState) {
+        const parsed = JSON.parse(savedState);
+        setState(parsed);
+      }
+    } catch (error) {
+      console.error('Failed to load signup progress:', error);
+    }
+  }, []);
+
+  // Save state to localStorage whenever it changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(SIGNUP_STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.error('Failed to save signup progress:', error);
+    }
+  }, [state]);
+
+  const handleNextStep = () => {
+    if (state.currentStep < 3) {
+      setState(prev => ({
+        ...prev,
+        currentStep: (prev.currentStep + 1) as 1 | 2 | 3,
+        errors: {},
+      }));
+    }
+  };
+
+  const handleBackStep = () => {
+    if (state.currentStep > 1) {
+      setState(prev => ({
+        ...prev,
+        currentStep: (prev.currentStep - 1) as 1 | 2 | 3,
+        errors: {},
+      }));
+    }
+  };
+
+  const handleSignupSubmit = async () => {
+    try {
+      setState(prev => ({ ...prev, loading: true, errors: {} }));
+
+      // Validate required terms
+      if (!state.termsData.serviceTerms || !state.termsData.privacyPolicy) {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          errors: { terms: '필수 약관에 동의해주세요' },
+        }));
+        return;
+      }
+
+      // Save user profile to Firestore
+      const userRef = doc(db, 'users', state.accountData.uid);
+      await setDoc(userRef, {
+        uid: state.accountData.uid,
+        email: state.accountData.email,
+        displayName: state.accountData.displayName,
+        photoURL: state.accountData.photoURL,
+        provider: state.accountData.provider,
+        profile: {
+          nickname: state.profileData.nickname,
+          danceLevel: state.profileData.danceLevel,
+          location: state.profileData.location,
+          bio: state.profileData.bio,
+          interests: state.profileData.interests,
+        },
+        termsAgreed: {
+          serviceTerms: state.termsData.serviceTerms,
+          privacyPolicy: state.termsData.privacyPolicy,
+          marketingConsent: state.termsData.marketingConsent,
+          agreedAt: new Date().toISOString(),
+        },
+        createdAt: new Date().toISOString(),
+        lastLoginAt: new Date().toISOString(),
+      });
+
+      // Clear localStorage after successful signup
+      localStorage.removeItem(SIGNUP_STORAGE_KEY);
+
+      // Redirect to home
+      router.push('/home');
+    } catch (error: any) {
+      console.error('Signup failed:', error);
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        errors: { submit: error.message || '회원가입에 실패했습니다. 다시 시도해주세요.' },
+      }));
+    }
+  };
+
+  const updateAccountData = (data: Partial<SignupState['accountData']>) => {
+    setState(prev => ({
+      ...prev,
+      accountData: { ...prev.accountData, ...data },
+    }));
+  };
+
+  const updateProfileData = (data: Partial<SignupState['profileData']>) => {
+    setState(prev => ({
+      ...prev,
+      profileData: { ...prev.profileData, ...data },
+    }));
+  };
+
+  const updateTermsData = (data: Partial<SignupState['termsData']>) => {
+    setState(prev => ({
+      ...prev,
+      termsData: { ...prev.termsData, ...data },
+    }));
+  };
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '24px'
+    }}>
+      <div style={{
+        width: '100%',
+        maxWidth: '600px',
+        background: 'rgba(255, 255, 255, 0.95)',
+        borderRadius: '24px',
+        padding: '48px 32px',
+        boxShadow: '0 24px 48px rgba(0, 0, 0, 0.15)',
+      }}>
+        {/* Progress Indicator */}
+        <div style={{ marginBottom: '48px' }}>
+          <StepIndicator currentStep={state.currentStep} steps={SIGNUP_STEPS} />
+        </div>
+
+        {/* Step Content */}
+        <div style={{ marginBottom: '32px' }}>
+          {state.currentStep === 1 && (
+            <Step1AccountInfo
+              onNext={handleNextStep}
+              onUpdateAccountData={updateAccountData}
+            />
+          )}
+
+          {state.currentStep === 2 && (
+            <Step2ProfileInfo
+              profileData={state.profileData}
+              onNext={handleNextStep}
+              onBack={handleBackStep}
+              onUpdateProfileData={updateProfileData}
+            />
+          )}
+
+          {state.currentStep === 3 && (
+            <Step3Terms
+              termsData={state.termsData}
+              loading={state.loading}
+              onBack={handleBackStep}
+              onSubmit={handleSignupSubmit}
+              onUpdateTermsData={updateTermsData}
+            />
+          )}
+        </div>
+
+        {/* Error Messages */}
+        {Object.keys(state.errors).length > 0 && (
+          <div style={{
+            padding: '16px',
+            background: '#fee2e2',
+            border: '1px solid #fca5a5',
+            borderRadius: '12px',
+            marginBottom: '24px'
+          }}>
+            {Object.values(state.errors).map((error, index) => (
+              <p key={index} style={{ color: '#dc2626', fontSize: '14px', margin: 0 }}>
+                {error}
+              </p>
+            ))}
+          </div>
+        )}
+
+        {/* Helper Text */}
+        <p style={{
+          marginTop: '24px',
+          textAlign: 'center',
+          fontSize: '14px',
+          color: '#9ca3af'
+        }}>
+          이미 계정이 있으신가요?{' '}
+          <a
+            href="/login"
+            style={{
+              color: '#667eea',
+              textDecoration: 'none',
+              fontWeight: 600
+            }}
+          >
+            로그인
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/signup/components/Step1AccountInfo.tsx
+++ b/app/signup/components/Step1AccountInfo.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import React, { useState } from 'react';
+import SignupButton from './SignupButton';
+import { signInWithGoogle } from '@/lib/auth/providers';
+import type { SignupState } from '@/lib/types/signup';
+
+export interface Step1AccountInfoProps {
+  onNext: () => void;
+  onUpdateAccountData: (data: Partial<SignupState['accountData']>) => void;
+}
+
+const Step1AccountInfo: React.FC<Step1AccountInfoProps> = ({ onNext, onUpdateAccountData }) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+
+  const handleGoogleLogin = async () => {
+    try {
+      setLoading(true);
+      setError('');
+
+      // Call Firebase Google authentication
+      const user = await signInWithGoogle();
+
+      // Update account data in SignupWizard state
+      onUpdateAccountData({
+        provider: 'google',
+        uid: user.id,
+        email: user.email || '',
+        displayName: user.displayName || '',
+        photoURL: user.photoURL || '',
+      });
+
+      // Auto-advance to next step
+      onNext();
+    } catch (err: any) {
+      console.error('Google login failed:', err);
+
+      // Handle specific error codes first, then custom messages
+      if (err.code === 'auth/popup-blocked') {
+        setError('팝업이 차단되었습니다. 브라우저 설정에서 팝업을 허용해주세요.');
+      } else if (err.code === 'auth/popup-closed-by-user') {
+        setError('로그인이 취소되었습니다.');
+      } else if (err.code === 'auth/network-request-failed') {
+        setError('네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.');
+      } else if (err.message && typeof err.message === 'string') {
+        setError(err.message);
+      } else {
+        setError('로그인에 실패했습니다. 다시 시도해주세요.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="step1-container">
+        <div className="step1-card">
+          <div className="step1-header">
+            <h2 className="step1-title">소셜 계정으로 시작하기</h2>
+            <p className="step1-description">
+              Google 계정으로 간편하게 가입하고<br />
+              스윙댄스 커뮤니티에 참여하세요
+            </p>
+          </div>
+
+          <div className="step1-content">
+            {error && (
+              <div className="error-message" role="alert">
+                <span className="error-icon">⚠️</span>
+                <span className="error-text">{error}</span>
+              </div>
+            )}
+
+            <SignupButton
+              variant="social-google"
+              loading={loading}
+              onClick={handleGoogleLogin}
+              aria-label="Google로 계속하기"
+            >
+              Google로 계속하기
+            </SignupButton>
+
+            <div className="divider">
+              <span className="divider-text">안전하고 빠른 가입</span>
+            </div>
+
+            <div className="info-section">
+              <div className="info-item">
+                <span className="info-icon">🔒</span>
+                <span className="info-text">안전한 소셜 로그인</span>
+              </div>
+              <div className="info-item">
+                <span className="info-icon">⚡</span>
+                <span className="info-text">빠른 회원가입</span>
+              </div>
+              <div className="info-item">
+                <span className="info-icon">✨</span>
+                <span className="info-text">간편한 정보 입력</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <style jsx>{`
+        .step1-container {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          min-height: 60vh;
+          padding: 24px;
+        }
+
+        .step1-card {
+          background: rgba(255, 255, 255, 0.95);
+          backdrop-filter: blur(20px);
+          -webkit-backdrop-filter: blur(20px);
+          border-radius: 24px;
+          padding: 48px;
+          max-width: 480px;
+          width: 100%;
+          box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+          border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+
+        .step1-header {
+          text-align: center;
+          margin-bottom: 40px;
+        }
+
+        .step1-title {
+          font-size: 28px;
+          font-weight: 800;
+          color: #1a1a1a;
+          margin: 0 0 16px 0;
+          letter-spacing: -0.5px;
+        }
+
+        .step1-description {
+          font-size: 15px;
+          color: #666;
+          line-height: 1.6;
+          margin: 0;
+        }
+
+        .step1-content {
+          display: flex;
+          flex-direction: column;
+          gap: 20px;
+        }
+
+        .error-message {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          padding: 16px;
+          background: rgba(239, 68, 68, 0.1);
+          border-radius: 12px;
+          border: 1px solid rgba(239, 68, 68, 0.2);
+        }
+
+        .error-icon {
+          font-size: 20px;
+          flex-shrink: 0;
+        }
+
+        .error-text {
+          font-size: 14px;
+          color: #dc2626;
+          font-weight: 500;
+          line-height: 1.5;
+        }
+
+        .divider {
+          position: relative;
+          text-align: center;
+          margin: 12px 0;
+        }
+
+        .divider::before {
+          content: '';
+          position: absolute;
+          top: 50%;
+          left: 0;
+          right: 0;
+          height: 1px;
+          background: linear-gradient(
+            to right,
+            transparent,
+            rgba(0, 0, 0, 0.1),
+            transparent
+          );
+        }
+
+        .divider-text {
+          position: relative;
+          display: inline-block;
+          padding: 0 16px;
+          background: rgba(255, 255, 255, 0.95);
+          font-size: 13px;
+          color: #999;
+          font-weight: 500;
+        }
+
+        .info-section {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          padding: 20px;
+          background: linear-gradient(135deg, rgba(102, 126, 234, 0.05) 0%, rgba(118, 75, 162, 0.05) 100%);
+          border-radius: 16px;
+          border: 1px solid rgba(102, 126, 234, 0.1);
+        }
+
+        .info-item {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+        }
+
+        .info-icon {
+          font-size: 20px;
+          flex-shrink: 0;
+        }
+
+        .info-text {
+          font-size: 14px;
+          color: #4a5568;
+          font-weight: 500;
+        }
+
+        @media (max-width: 768px) {
+          .step1-container {
+            padding: 16px;
+            min-height: 50vh;
+          }
+
+          .step1-card {
+            padding: 32px 24px;
+            border-radius: 20px;
+          }
+
+          .step1-title {
+            font-size: 24px;
+          }
+
+          .step1-description {
+            font-size: 14px;
+          }
+
+          .info-section {
+            padding: 16px;
+          }
+        }
+
+        @media (max-width: 480px) {
+          .step1-card {
+            padding: 28px 20px;
+          }
+
+          .step1-title {
+            font-size: 22px;
+          }
+
+          .step1-header {
+            margin-bottom: 32px;
+          }
+        }
+      `}</style>
+    </>
+  );
+};
+
+Step1AccountInfo.displayName = 'Step1AccountInfo';
+
+export default Step1AccountInfo;

--- a/app/signup/components/Step2ProfileInfo.tsx
+++ b/app/signup/components/Step2ProfileInfo.tsx
@@ -1,0 +1,527 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import SignupButton from './SignupButton';
+import type { SignupState } from '@/lib/types/signup';
+import type { DanceLevel } from '@/lib/types/auth';
+import { DANCE_LEVELS, REGIONS, DANCE_STYLES, VALIDATION } from '@/lib/constants/profile';
+
+export interface Step2ProfileInfoProps {
+  profileData: SignupState['profileData'];
+  onNext: () => void;
+  onBack: () => void;
+  onUpdateProfileData: (data: Partial<SignupState['profileData']>) => void;
+}
+
+const Step2ProfileInfo: React.FC<Step2ProfileInfoProps> = ({
+  profileData,
+  onNext,
+  onBack,
+  onUpdateProfileData,
+}) => {
+  const [localData, setLocalData] = useState(profileData);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  // Sync with parent when profileData changes
+  useEffect(() => {
+    setLocalData(profileData);
+  }, [profileData]);
+
+  const validateNickname = (nickname: string): string | null => {
+    if (!nickname.trim()) {
+      return VALIDATION.NICKNAME.ERROR_MESSAGES.REQUIRED;
+    }
+    if (nickname.length < VALIDATION.NICKNAME.MIN_LENGTH) {
+      return VALIDATION.NICKNAME.ERROR_MESSAGES.MIN_LENGTH;
+    }
+    if (nickname.length > VALIDATION.NICKNAME.MAX_LENGTH) {
+      return VALIDATION.NICKNAME.ERROR_MESSAGES.MAX_LENGTH;
+    }
+    if (!VALIDATION.NICKNAME.PATTERN.test(nickname)) {
+      return VALIDATION.NICKNAME.ERROR_MESSAGES.PATTERN;
+    }
+    return null;
+  };
+
+  const validateLocation = (location: string): string | null => {
+    if (!location) {
+      return VALIDATION.LOCATION.ERROR_MESSAGES.REQUIRED;
+    }
+    return null;
+  };
+
+  const validateBio = (bio: string): string | null => {
+    if (bio.length > VALIDATION.BIO.MAX_LENGTH) {
+      return VALIDATION.BIO.ERROR_MESSAGES.MAX_LENGTH;
+    }
+    return null;
+  };
+
+  const handleFieldChange = (field: keyof SignupState['profileData'], value: any) => {
+    const newData = { ...localData, [field]: value };
+    setLocalData(newData);
+
+    // Clear error for this field
+    setErrors(prev => ({ ...prev, [field]: '' }));
+
+    // Update parent immediately
+    onUpdateProfileData({ [field]: value });
+  };
+
+  const handleBlur = (field: keyof SignupState['profileData']) => {
+    setTouched(prev => ({ ...prev, [field]: true }));
+
+    // Validate on blur
+    let error: string | null = null;
+    if (field === 'nickname') {
+      error = validateNickname(localData.nickname);
+    } else if (field === 'location') {
+      error = validateLocation(localData.location);
+    } else if (field === 'bio') {
+      error = validateBio(localData.bio);
+    }
+
+    if (error) {
+      setErrors(prev => ({ ...prev, [field]: error }));
+    }
+  };
+
+  const handleInterestToggle = (interestValue: string) => {
+    const currentInterests = localData.interests || [];
+    const newInterests = currentInterests.includes(interestValue)
+      ? currentInterests.filter(i => i !== interestValue)
+      : [...currentInterests, interestValue];
+
+    handleFieldChange('interests', newInterests);
+  };
+
+  const handleNext = () => {
+    // Validate all required fields
+    const nicknameError = validateNickname(localData.nickname);
+    const locationError = validateLocation(localData.location);
+    const bioError = validateBio(localData.bio);
+
+    const newErrors: Record<string, string> = {};
+    if (nicknameError) newErrors.nickname = nicknameError;
+    if (locationError) newErrors.location = locationError;
+    if (bioError) newErrors.bio = bioError;
+
+    setErrors(newErrors);
+
+    // Mark all required fields as touched
+    setTouched({
+      nickname: true,
+      danceLevel: true,
+      location: true,
+      bio: true,
+      interests: true,
+    });
+
+    // If no errors, proceed to next step
+    if (Object.keys(newErrors).length === 0) {
+      onNext();
+    }
+  };
+
+  const isFormValid =
+    !validateNickname(localData.nickname) &&
+    !validateLocation(localData.location) &&
+    !validateBio(localData.bio);
+
+  const bioLength = localData.bio.length;
+  const isBioOverLimit = bioLength > VALIDATION.BIO.MAX_LENGTH;
+
+  return (
+    <>
+      <div className="step2-container">
+        <div className="step2-card">
+          <div className="step2-header">
+            <h2 className="step2-title">프로필 정보 입력</h2>
+            <p className="step2-description">
+              스윙댄스 커뮤니티에서 사용할<br />
+              프로필 정보를 입력해주세요
+            </p>
+          </div>
+
+          <div className="step2-content">
+            {/* Nickname Field */}
+            <div className="field-group">
+              <label htmlFor="nickname" className="field-label required">
+                닉네임
+              </label>
+              <input
+                id="nickname"
+                type="text"
+                className={`field-input ${errors.nickname && touched.nickname ? 'error' : ''}`}
+                value={localData.nickname}
+                onChange={(e) => handleFieldChange('nickname', e.target.value)}
+                onBlur={() => handleBlur('nickname')}
+                placeholder="닉네임을 입력하세요 (2-20자)"
+                maxLength={VALIDATION.NICKNAME.MAX_LENGTH}
+                aria-invalid={!!(errors.nickname && touched.nickname)}
+                aria-describedby={errors.nickname && touched.nickname ? 'nickname-error' : undefined}
+              />
+              {errors.nickname && touched.nickname && (
+                <span id="nickname-error" className="field-error" role="alert">
+                  {errors.nickname}
+                </span>
+              )}
+            </div>
+
+            {/* Dance Level Field */}
+            <div className="field-group">
+              <label htmlFor="danceLevel" className="field-label required">
+                댄스 레벨
+              </label>
+              <select
+                id="danceLevel"
+                className="field-select"
+                value={localData.danceLevel}
+                onChange={(e) => handleFieldChange('danceLevel', e.target.value as DanceLevel)}
+                aria-label="댄스 레벨 선택"
+              >
+                {DANCE_LEVELS.map((level) => (
+                  <option key={level.value} value={level.value}>
+                    {level.label} - {level.description}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Location Field */}
+            <div className="field-group">
+              <label htmlFor="location" className="field-label required">
+                활동 지역
+              </label>
+              <select
+                id="location"
+                className={`field-select ${errors.location && touched.location ? 'error' : ''}`}
+                value={localData.location}
+                onChange={(e) => handleFieldChange('location', e.target.value)}
+                onBlur={() => handleBlur('location')}
+                aria-invalid={!!(errors.location && touched.location)}
+                aria-describedby={errors.location && touched.location ? 'location-error' : undefined}
+              >
+                <option value="">지역을 선택하세요</option>
+                {REGIONS.map((region) => (
+                  <option key={region.value} value={region.value}>
+                    {region.label}
+                  </option>
+                ))}
+              </select>
+              {errors.location && touched.location && (
+                <span id="location-error" className="field-error" role="alert">
+                  {errors.location}
+                </span>
+              )}
+            </div>
+
+            {/* Bio Field (Optional) */}
+            <div className="field-group">
+              <label htmlFor="bio" className="field-label">
+                자기소개 <span className="optional-label">(선택)</span>
+              </label>
+              <textarea
+                id="bio"
+                className={`field-textarea ${isBioOverLimit ? 'error' : ''}`}
+                value={localData.bio}
+                onChange={(e) => handleFieldChange('bio', e.target.value)}
+                onBlur={() => handleBlur('bio')}
+                placeholder="간단한 자기소개를 작성해주세요"
+                rows={4}
+                aria-invalid={isBioOverLimit}
+                aria-describedby="bio-counter"
+              />
+              <div
+                id="bio-counter"
+                className={`char-counter ${isBioOverLimit ? 'over-limit' : ''}`}
+                aria-live="polite"
+              >
+                {bioLength} / {VALIDATION.BIO.MAX_LENGTH}
+              </div>
+              {errors.bio && touched.bio && (
+                <span className="field-error" role="alert">
+                  {errors.bio}
+                </span>
+              )}
+            </div>
+
+            {/* Dance Styles (Optional) */}
+            <div className="field-group">
+              <label className="field-label">
+                관심 댄스 스타일 <span className="optional-label">(선택)</span>
+              </label>
+              <div className="chip-container" role="group" aria-label="관심 댄스 스타일 선택">
+                {DANCE_STYLES.map((style) => {
+                  const isSelected = localData.interests.includes(style.value);
+                  return (
+                    <button
+                      key={style.value}
+                      type="button"
+                      className={`chip ${isSelected ? 'selected' : ''}`}
+                      onClick={() => handleInterestToggle(style.value)}
+                      aria-pressed={isSelected}
+                      aria-label={`${style.label} ${isSelected ? '선택됨' : '선택 안됨'}`}
+                    >
+                      {style.icon && <span className="chip-icon">{style.icon}</span>}
+                      <span className="chip-label">{style.label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="button-group">
+              <SignupButton
+                variant="primary"
+                onClick={onBack}
+                type="button"
+                style={{ flex: 1 }}
+                aria-label="이전 단계로"
+                data-testid="back-button"
+              >
+                이전
+              </SignupButton>
+              <SignupButton
+                variant="primary"
+                onClick={handleNext}
+                disabled={!isFormValid}
+                type="button"
+                style={{ flex: 2 }}
+                aria-label="다음 단계로"
+                data-testid="next-button"
+              >
+                다음
+              </SignupButton>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <style jsx>{`
+        .step2-container {
+          display: flex;
+          justify-content: center;
+          align-items: flex-start;
+          min-height: 70vh;
+          padding: 24px;
+        }
+
+        .step2-card {
+          background: rgba(255, 255, 255, 0.95);
+          backdrop-filter: blur(20px);
+          -webkit-backdrop-filter: blur(20px);
+          border-radius: 24px;
+          padding: 48px;
+          max-width: 560px;
+          width: 100%;
+          box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+          border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+
+        .step2-header {
+          text-align: center;
+          margin-bottom: 40px;
+        }
+
+        .step2-title {
+          font-size: 28px;
+          font-weight: 800;
+          color: #1a1a1a;
+          margin: 0 0 16px 0;
+          letter-spacing: -0.5px;
+        }
+
+        .step2-description {
+          font-size: 15px;
+          color: #666;
+          line-height: 1.6;
+          margin: 0;
+        }
+
+        .step2-content {
+          display: flex;
+          flex-direction: column;
+          gap: 24px;
+        }
+
+        .field-group {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+
+        .field-label {
+          font-size: 14px;
+          font-weight: 600;
+          color: #333;
+        }
+
+        .field-label.required::after {
+          content: ' *';
+          color: #ef4444;
+        }
+
+        .optional-label {
+          font-weight: 400;
+          color: #999;
+          font-size: 13px;
+        }
+
+        .field-input,
+        .field-select,
+        .field-textarea {
+          width: 100%;
+          padding: 14px 16px;
+          border: 2px solid #e5e7eb;
+          border-radius: 12px;
+          font-size: 15px;
+          color: #1a1a1a;
+          background: white;
+          transition: all 0.2s ease;
+          font-family: inherit;
+        }
+
+        .field-input:focus,
+        .field-select:focus,
+        .field-textarea:focus {
+          outline: none;
+          border-color: #693BF2;
+          box-shadow: 0 0 0 3px rgba(105, 59, 242, 0.1);
+        }
+
+        .field-input.error,
+        .field-select.error,
+        .field-textarea.error {
+          border-color: #ef4444;
+        }
+
+        .field-textarea {
+          resize: vertical;
+          min-height: 100px;
+        }
+
+        .field-error {
+          font-size: 13px;
+          color: #ef4444;
+          font-weight: 500;
+        }
+
+        .char-counter {
+          font-size: 13px;
+          color: #999;
+          text-align: right;
+          margin-top: -4px;
+        }
+
+        .char-counter.over-limit {
+          color: #ef4444;
+          font-weight: 600;
+        }
+
+        .chip-container {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+        }
+
+        .chip {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 10px 16px;
+          border: 2px solid #e5e7eb;
+          border-radius: 24px;
+          background: white;
+          font-size: 14px;
+          font-weight: 500;
+          color: #666;
+          cursor: pointer;
+          transition: all 0.2s ease;
+        }
+
+        .chip:hover {
+          border-color: #693BF2;
+          background: rgba(105, 59, 242, 0.05);
+        }
+
+        .chip.selected {
+          border-color: #693BF2;
+          background: #693BF2;
+          color: white;
+        }
+
+        .chip-icon {
+          font-size: 16px;
+          line-height: 1;
+        }
+
+        .chip-label {
+          line-height: 1;
+        }
+
+        .button-group {
+          display: flex;
+          gap: 12px;
+          margin-top: 16px;
+        }
+
+        @media (max-width: 768px) {
+          .step2-container {
+            padding: 16px;
+          }
+
+          .step2-card {
+            padding: 32px 24px;
+            border-radius: 20px;
+          }
+
+          .step2-title {
+            font-size: 24px;
+          }
+
+          .step2-description {
+            font-size: 14px;
+          }
+
+          .step2-content {
+            gap: 20px;
+          }
+
+          .button-group {
+            flex-direction: column;
+          }
+
+          .button-group > * {
+            flex: 1 !important;
+          }
+        }
+
+        @media (max-width: 480px) {
+          .step2-card {
+            padding: 28px 20px;
+          }
+
+          .step2-title {
+            font-size: 22px;
+          }
+
+          .step2-header {
+            margin-bottom: 32px;
+          }
+
+          .chip {
+            padding: 8px 14px;
+            font-size: 13px;
+          }
+        }
+      `}</style>
+    </>
+  );
+};
+
+Step2ProfileInfo.displayName = 'Step2ProfileInfo';
+
+export default Step2ProfileInfo;

--- a/app/signup/components/Step3Terms.tsx
+++ b/app/signup/components/Step3Terms.tsx
@@ -1,0 +1,456 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import SignupButton from './SignupButton';
+import type { SignupState } from '@/lib/types/signup';
+
+export interface Step3TermsProps {
+  termsData: SignupState['termsData'];
+  loading: boolean;
+  onBack: () => void;
+  onSubmit: () => void;
+  onUpdateTermsData: (data: Partial<SignupState['termsData']>) => void;
+}
+
+const Step3Terms: React.FC<Step3TermsProps> = ({
+  termsData,
+  loading,
+  onBack,
+  onSubmit,
+  onUpdateTermsData,
+}) => {
+  const [localData, setLocalData] = useState(termsData);
+
+  // Sync with parent when termsData changes
+  useEffect(() => {
+    setLocalData(termsData);
+  }, [termsData]);
+
+  // Check if all terms are agreed (for "agree all" checkbox)
+  const allAgreed =
+    localData.serviceTerms && localData.privacyPolicy && localData.marketingConsent;
+
+  // Check if required terms are agreed (for submit button)
+  const requiredAgreed = localData.serviceTerms && localData.privacyPolicy;
+
+  const handleTermChange = (term: keyof SignupState['termsData'], value: boolean) => {
+    const newData = { ...localData, [term]: value };
+    setLocalData(newData);
+    onUpdateTermsData({ [term]: value });
+  };
+
+  const handleAgreeAll = () => {
+    const newValue = !allAgreed;
+    const newData = {
+      serviceTerms: newValue,
+      privacyPolicy: newValue,
+      marketingConsent: newValue,
+    };
+    setLocalData(newData);
+    onUpdateTermsData(newData);
+  };
+
+  const handleSubmit = () => {
+    if (requiredAgreed && !loading) {
+      onSubmit();
+    }
+  };
+
+  const handleViewTerms = (type: 'service' | 'privacy') => {
+    const url = type === 'service' ? '/terms/service' : '/terms/privacy';
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <>
+      <div className="step3-container">
+        <div className="step3-card">
+          <div className="step3-header">
+            <h2 className="step3-title">약관 동의</h2>
+            <p className="step3-description">
+              서비스 이용을 위해<br />
+              약관에 동의해주세요
+            </p>
+          </div>
+
+          <div className="step3-content">
+            {/* Agree All Checkbox */}
+            <div className="checkbox-item all">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  className="checkbox-input"
+                  checked={allAgreed}
+                  onChange={handleAgreeAll}
+                  aria-label="전체 동의"
+                />
+                <span className="checkbox-custom" aria-hidden="true">
+                  {allAgreed && <span className="checkmark">✓</span>}
+                </span>
+                <span className="checkbox-text">전체 동의</span>
+              </label>
+            </div>
+
+            <div className="divider" />
+
+            {/* Service Terms (Required) */}
+            <div className="checkbox-item">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  className="checkbox-input"
+                  checked={localData.serviceTerms}
+                  onChange={(e) => handleTermChange('serviceTerms', e.target.checked)}
+                  aria-label="서비스 이용약관 동의 (필수)"
+                  aria-required="true"
+                />
+                <span className="checkbox-custom" aria-hidden="true">
+                  {localData.serviceTerms && <span className="checkmark">✓</span>}
+                </span>
+                <span className="checkbox-text">
+                  <span className="term-title">
+                    서비스 이용약관 <span className="required">(필수)</span>
+                  </span>
+                </span>
+              </label>
+              <button
+                type="button"
+                className="view-link"
+                onClick={() => handleViewTerms('service')}
+                aria-label="서비스 이용약관 보기"
+              >
+                보기
+              </button>
+            </div>
+
+            {/* Privacy Policy (Required) */}
+            <div className="checkbox-item">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  className="checkbox-input"
+                  checked={localData.privacyPolicy}
+                  onChange={(e) => handleTermChange('privacyPolicy', e.target.checked)}
+                  aria-label="개인정보 처리방침 동의 (필수)"
+                  aria-required="true"
+                />
+                <span className="checkbox-custom" aria-hidden="true">
+                  {localData.privacyPolicy && <span className="checkmark">✓</span>}
+                </span>
+                <span className="checkbox-text">
+                  <span className="term-title">
+                    개인정보 처리방침 <span className="required">(필수)</span>
+                  </span>
+                </span>
+              </label>
+              <button
+                type="button"
+                className="view-link"
+                onClick={() => handleViewTerms('privacy')}
+                aria-label="개인정보 처리방침 보기"
+              >
+                보기
+              </button>
+            </div>
+
+            {/* Marketing Consent (Optional) */}
+            <div className="checkbox-item">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  className="checkbox-input"
+                  checked={localData.marketingConsent}
+                  onChange={(e) => handleTermChange('marketingConsent', e.target.checked)}
+                  aria-label="마케팅 정보 수신 동의 (선택)"
+                />
+                <span className="checkbox-custom" aria-hidden="true">
+                  {localData.marketingConsent && <span className="checkmark">✓</span>}
+                </span>
+                <span className="checkbox-text">
+                  <span className="term-title">마케팅 정보 수신 동의 <span className="optional">(선택)</span></span>
+                  <span className="term-description">
+                    이벤트, 프로모션 등 마케팅 정보를 이메일로 받아보실 수 있습니다.
+                  </span>
+                </span>
+              </label>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="button-group">
+              <SignupButton
+                variant="primary"
+                onClick={onBack}
+                disabled={loading}
+                type="button"
+                style={{ flex: 1 }}
+                aria-label="이전 단계로"
+                data-testid="back-button"
+              >
+                이전
+              </SignupButton>
+              <SignupButton
+                variant="primary"
+                onClick={handleSubmit}
+                disabled={!requiredAgreed || loading}
+                loading={loading}
+                type="button"
+                style={{ flex: 2 }}
+                aria-label="회원가입 완료"
+                data-testid="submit-button"
+              >
+                {loading ? '처리 중...' : '회원가입 완료'}
+              </SignupButton>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <style jsx>{`
+        .step3-container {
+          display: flex;
+          justify-content: center;
+          align-items: flex-start;
+          min-height: 70vh;
+          padding: 24px;
+        }
+
+        .step3-card {
+          background: rgba(255, 255, 255, 0.95);
+          backdrop-filter: blur(20px);
+          -webkit-backdrop-filter: blur(20px);
+          border-radius: 24px;
+          padding: 48px;
+          max-width: 560px;
+          width: 100%;
+          box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+          border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+
+        .step3-header {
+          text-align: center;
+          margin-bottom: 40px;
+        }
+
+        .step3-title {
+          font-size: 28px;
+          font-weight: 800;
+          color: #1a1a1a;
+          margin: 0 0 16px 0;
+          letter-spacing: -0.5px;
+        }
+
+        .step3-description {
+          font-size: 15px;
+          color: #666;
+          line-height: 1.6;
+          margin: 0;
+        }
+
+        .step3-content {
+          display: flex;
+          flex-direction: column;
+          gap: 20px;
+        }
+
+        .checkbox-item {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          padding: 16px;
+          border-radius: 12px;
+          transition: background-color 0.2s ease;
+        }
+
+        .checkbox-item:hover {
+          background: rgba(105, 59, 242, 0.03);
+        }
+
+        .checkbox-item.all {
+          background: linear-gradient(135deg, rgba(102, 126, 234, 0.08) 0%, rgba(118, 75, 162, 0.08) 100%);
+          border: 2px solid rgba(105, 59, 242, 0.2);
+          padding: 20px;
+          font-weight: 600;
+        }
+
+        .checkbox-label {
+          display: flex;
+          align-items: flex-start;
+          gap: 12px;
+          cursor: pointer;
+          flex: 1;
+        }
+
+        .checkbox-input {
+          position: absolute;
+          opacity: 0;
+          width: 0;
+          height: 0;
+        }
+
+        .checkbox-custom {
+          position: relative;
+          width: 24px;
+          height: 24px;
+          border: 2px solid #d1d5db;
+          border-radius: 6px;
+          background: white;
+          transition: all 0.2s ease;
+          flex-shrink: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        .checkbox-input:checked + .checkbox-custom {
+          background: #693BF2;
+          border-color: #693BF2;
+        }
+
+        .checkbox-input:focus + .checkbox-custom {
+          outline: 2px solid #693BF2;
+          outline-offset: 2px;
+        }
+
+        .checkmark {
+          color: white;
+          font-size: 16px;
+          font-weight: bold;
+          line-height: 1;
+        }
+
+        .checkbox-text {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          flex: 1;
+        }
+
+        .term-title {
+          font-size: 15px;
+          color: #1a1a1a;
+          font-weight: 500;
+        }
+
+        .term-description {
+          font-size: 13px;
+          color: #666;
+          line-height: 1.5;
+        }
+
+        .required {
+          color: #ef4444;
+          font-weight: 600;
+        }
+
+        .optional {
+          color: #999;
+          font-weight: 400;
+        }
+
+        .view-link {
+          font-size: 14px;
+          color: #693BF2;
+          background: none;
+          border: none;
+          cursor: pointer;
+          text-decoration: underline;
+          padding: 0 8px;
+          flex-shrink: 0;
+          transition: color 0.2s ease;
+        }
+
+        .view-link:hover {
+          color: #5729d1;
+        }
+
+        .view-link:focus {
+          outline: 2px solid #693BF2;
+          outline-offset: 2px;
+          border-radius: 4px;
+        }
+
+        .divider {
+          height: 1px;
+          background: linear-gradient(
+            to right,
+            transparent,
+            rgba(0, 0, 0, 0.1),
+            transparent
+          );
+          margin: 8px 0;
+        }
+
+        .button-group {
+          display: flex;
+          gap: 12px;
+          margin-top: 16px;
+        }
+
+        @media (max-width: 768px) {
+          .step3-container {
+            padding: 16px;
+          }
+
+          .step3-card {
+            padding: 32px 24px;
+            border-radius: 20px;
+          }
+
+          .step3-title {
+            font-size: 24px;
+          }
+
+          .step3-description {
+            font-size: 14px;
+          }
+
+          .step3-content {
+            gap: 16px;
+          }
+
+          .checkbox-item {
+            padding: 12px;
+          }
+
+          .checkbox-item.all {
+            padding: 16px;
+          }
+
+          .button-group {
+            flex-direction: column;
+          }
+
+          .button-group > * {
+            flex: 1 !important;
+          }
+        }
+
+        @media (max-width: 480px) {
+          .step3-card {
+            padding: 28px 20px;
+          }
+
+          .step3-title {
+            font-size: 22px;
+          }
+
+          .step3-header {
+            margin-bottom: 32px;
+          }
+
+          .term-title {
+            font-size: 14px;
+          }
+
+          .term-description {
+            font-size: 12px;
+          }
+        }
+      `}</style>
+    </>
+  );
+};
+
+Step3Terms.displayName = 'Step3Terms';
+
+export default Step3Terms;

--- a/app/signup/components/StepIndicator.tsx
+++ b/app/signup/components/StepIndicator.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import React from 'react';
+
+export interface Step {
+  number: number;
+  label: string;
+}
+
+export interface StepIndicatorProps {
+  currentStep: 1 | 2 | 3;
+  steps: Step[];
+}
+
+const StepIndicator = React.memo<StepIndicatorProps>(({ currentStep, steps }) => {
+  const getStepStatus = (stepNumber: number): 'completed' | 'in_progress' | 'pending' => {
+    if (stepNumber < currentStep) return 'completed';
+    if (stepNumber === currentStep) return 'in_progress';
+    return 'pending';
+  };
+
+  const getStepColor = (status: string) => {
+    const colorMap = {
+      completed: '#10b981', // 초록색
+      in_progress: '#667eea', // 보라색
+      pending: '#d1d5db', // 회색
+    };
+    return colorMap[status as keyof typeof colorMap];
+  };
+
+  return (
+    <>
+      <div className="step-indicator" role="progressbar" aria-valuenow={currentStep} aria-valuemin={1} aria-valuemax={3}>
+        {steps.map((step, index) => {
+          const status = getStepStatus(step.number);
+          const isLastStep = index === steps.length - 1;
+
+          return (
+            <div key={step.number} className="step-item">
+              {/* Step Circle */}
+              <div className={`step-circle ${status}`}>
+                {status === 'completed' ? (
+                  <svg className="check-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  <span className="step-number">{step.number}</span>
+                )}
+              </div>
+
+              {/* Step Label */}
+              <div className={`step-label ${status}`}>
+                {step.label}
+              </div>
+
+              {/* Connector Line */}
+              {!isLastStep && (
+                <div className="connector-container">
+                  <div className={`connector-line ${status}`}></div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <style jsx>{`
+        .step-indicator {
+          display: flex;
+          align-items: flex-start;
+          justify-content: center;
+          gap: 8px;
+          padding: 24px 0;
+          margin: 0 auto;
+          max-width: 600px;
+        }
+
+        .step-item {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          flex: 1;
+          position: relative;
+        }
+
+        .step-circle {
+          width: 48px;
+          height: 48px;
+          border-radius: 50%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-weight: 700;
+          font-size: 18px;
+          transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+          z-index: 2;
+        }
+
+        .step-circle.completed {
+          background: #10b981;
+          color: white;
+          animation: pulse 0.5s ease-out;
+        }
+
+        .step-circle.in_progress {
+          background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+          color: white;
+          animation: glow 2s ease-in-out infinite;
+        }
+
+        .step-circle.pending {
+          background: #f3f4f6;
+          color: #9ca3af;
+          border: 2px solid #e5e7eb;
+        }
+
+        .check-icon {
+          width: 24px;
+          height: 24px;
+        }
+
+        .step-number {
+          font-size: 18px;
+        }
+
+        .step-label {
+          margin-top: 12px;
+          font-size: 14px;
+          font-weight: 600;
+          text-align: center;
+          transition: color 0.3s ease;
+          white-space: nowrap;
+        }
+
+        .step-label.completed {
+          color: #10b981;
+        }
+
+        .step-label.in_progress {
+          color: #667eea;
+        }
+
+        .step-label.pending {
+          color: #9ca3af;
+        }
+
+        .connector-container {
+          position: absolute;
+          top: 24px;
+          left: calc(50% + 24px);
+          right: calc(-50% + 24px);
+          height: 4px;
+          z-index: 1;
+        }
+
+        .connector-line {
+          height: 100%;
+          border-radius: 2px;
+          transition: all 0.5s ease-in-out;
+        }
+
+        .connector-line.completed {
+          background: linear-gradient(90deg, #10b981 0%, #10b981 100%);
+          animation: fillLine 0.5s ease-out;
+        }
+
+        .connector-line.in_progress {
+          background: linear-gradient(90deg, #667eea 0%, #d1d5db 100%);
+        }
+
+        .connector-line.pending {
+          background: #e5e7eb;
+        }
+
+        @keyframes pulse {
+          0% {
+            transform: scale(1);
+            box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+          }
+          50% {
+            transform: scale(1.1);
+            box-shadow: 0 6px 20px rgba(16, 185, 129, 0.5);
+          }
+          100% {
+            transform: scale(1);
+            box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+          }
+        }
+
+        @keyframes glow {
+          0%, 100% {
+            box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+          }
+          50% {
+            box-shadow: 0 6px 20px rgba(102, 126, 234, 0.6);
+          }
+        }
+
+        @keyframes fillLine {
+          from {
+            transform: scaleX(0);
+            transform-origin: left;
+          }
+          to {
+            transform: scaleX(1);
+            transform-origin: left;
+          }
+        }
+
+        /* 반응형 디자인 */
+        @media (max-width: 768px) {
+          .step-indicator {
+            gap: 4px;
+            padding: 16px 0;
+          }
+
+          .step-circle {
+            width: 40px;
+            height: 40px;
+            font-size: 16px;
+          }
+
+          .check-icon {
+            width: 20px;
+            height: 20px;
+          }
+
+          .step-number {
+            font-size: 16px;
+          }
+
+          .step-label {
+            font-size: 12px;
+            margin-top: 8px;
+          }
+
+          .connector-container {
+            top: 20px;
+            left: calc(50% + 20px);
+            right: calc(-50% + 20px);
+            height: 3px;
+          }
+        }
+
+        @media (max-width: 480px) {
+          .step-circle {
+            width: 36px;
+            height: 36px;
+            font-size: 14px;
+          }
+
+          .step-label {
+            font-size: 11px;
+          }
+        }
+      `}</style>
+    </>
+  );
+});
+
+StepIndicator.displayName = 'StepIndicator';
+
+export default StepIndicator;

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react';
+import SignupWizard from './components/SignupWizard';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '회원가입 | Swing Connect',
+  description: '스윙댄스 커뮤니티 Swing Connect에 가입하세요',
+};
+
+function SignupLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-indigo-50 to-blue-50 flex items-center justify-center">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto"></div>
+        <p className="mt-4 text-gray-600">로딩 중...</p>
+      </div>
+    </div>
+  );
+}
+
+export default function SignupPage() {
+  return (
+    <Suspense fallback={<SignupLoading />}>
+      <SignupWizard />
+    </Suspense>
+  );
+}

--- a/lib/constants/profile.ts
+++ b/lib/constants/profile.ts
@@ -1,0 +1,105 @@
+/**
+ * Profile-related constants for Swing Connect
+ */
+
+import type { DanceLevel } from '../types/auth';
+
+// Dance levels with display labels
+export interface DanceLevelOption {
+  value: DanceLevel;
+  label: string;
+  description: string;
+}
+
+export const DANCE_LEVELS: DanceLevelOption[] = [
+  {
+    value: 'beginner',
+    label: '초급',
+    description: '6개월 미만 또는 기본 스텝 학습 중'
+  },
+  {
+    value: 'intermediate',
+    label: '중급',
+    description: '6개월~2년 또는 사교춤 가능'
+  },
+  {
+    value: 'advanced',
+    label: '고급',
+    description: '2년 이상 또는 대회 참가 경험'
+  },
+  {
+    value: 'professional',
+    label: '전문가',
+    description: '강사 또는 전문 댄서'
+  },
+];
+
+// Korean regions/cities
+export interface RegionOption {
+  value: string;
+  label: string;
+}
+
+export const REGIONS: RegionOption[] = [
+  { value: 'seoul', label: '서울' },
+  { value: 'gyeonggi', label: '경기' },
+  { value: 'busan', label: '부산' },
+  { value: 'daegu', label: '대구' },
+  { value: 'incheon', label: '인천' },
+  { value: 'gwangju', label: '광주' },
+  { value: 'daejeon', label: '대전' },
+  { value: 'ulsan', label: '울산' },
+  { value: 'sejong', label: '세종' },
+  { value: 'gangwon', label: '강원' },
+  { value: 'chungbuk', label: '충북' },
+  { value: 'chungnam', label: '충남' },
+  { value: 'jeonbuk', label: '전북' },
+  { value: 'jeonnam', label: '전남' },
+  { value: 'gyeongbuk', label: '경북' },
+  { value: 'gyeongnam', label: '경남' },
+  { value: 'jeju', label: '제주' },
+];
+
+// Dance styles/interests
+export interface DanceStyleOption {
+  value: string;
+  label: string;
+  icon?: string;
+}
+
+export const DANCE_STYLES: DanceStyleOption[] = [
+  { value: 'lindy-hop', label: '린디합', icon: '🎷' },
+  { value: 'charleston', label: '찰스턴', icon: '🎹' },
+  { value: 'balboa', label: '발보아', icon: '🎺' },
+  { value: 'blues', label: '블루스', icon: '🎵' },
+  { value: 'solo-jazz', label: '솔로 재즈', icon: '💃' },
+  { value: 'authentic-jazz', label: '어썬틱 재즈', icon: '🕺' },
+  { value: 'shag', label: '쉐그', icon: '🎶' },
+  { value: 'boogie-woogie', label: '부기우기', icon: '🎼' },
+];
+
+// Validation constants
+export const VALIDATION = {
+  NICKNAME: {
+    MIN_LENGTH: 2,
+    MAX_LENGTH: 20,
+    PATTERN: /^[a-zA-Z0-9가-힣]{2,20}$/,
+    ERROR_MESSAGES: {
+      REQUIRED: '닉네임을 입력해주세요',
+      PATTERN: '닉네임은 2-20자의 한글, 영문, 숫자만 가능합니다',
+      MIN_LENGTH: '닉네임은 최소 2자 이상이어야 합니다',
+      MAX_LENGTH: '닉네임은 최대 20자까지 가능합니다',
+    },
+  },
+  BIO: {
+    MAX_LENGTH: 200,
+    ERROR_MESSAGES: {
+      MAX_LENGTH: '자기소개는 최대 200자까지 가능합니다',
+    },
+  },
+  LOCATION: {
+    ERROR_MESSAGES: {
+      REQUIRED: '활동 지역을 선택해주세요',
+    },
+  },
+};

--- a/lib/types/signup.ts
+++ b/lib/types/signup.ts
@@ -1,0 +1,79 @@
+/**
+ * Signup wizard type definitions for Swing Connect
+ */
+
+import type { DanceLevel, AuthProvider } from './auth';
+
+export interface SignupState {
+  // Current step in the wizard (1, 2, or 3)
+  currentStep: 1 | 2 | 3;
+
+  // Step 1: Account information (from social login)
+  accountData: {
+    provider: AuthProvider | null;
+    uid: string;
+    email: string;
+    displayName: string;
+    photoURL: string;
+  };
+
+  // Step 2: Profile information
+  profileData: {
+    nickname: string;
+    danceLevel: DanceLevel;
+    location: string;
+    bio: string;
+    interests: string[];
+  };
+
+  // Step 3: Terms agreement
+  termsData: {
+    serviceTerms: boolean;
+    privacyPolicy: boolean;
+    marketingConsent: boolean;
+  };
+
+  // Error handling
+  errors: Record<string, string>;
+
+  // Loading state
+  loading: boolean;
+}
+
+export const INITIAL_SIGNUP_STATE: SignupState = {
+  currentStep: 1,
+  accountData: {
+    provider: null,
+    uid: '',
+    email: '',
+    displayName: '',
+    photoURL: '',
+  },
+  profileData: {
+    nickname: '',
+    danceLevel: 'beginner',
+    location: '',
+    bio: '',
+    interests: [],
+  },
+  termsData: {
+    serviceTerms: false,
+    privacyPolicy: false,
+    marketingConsent: false,
+  },
+  errors: {},
+  loading: false,
+};
+
+export const SIGNUP_STORAGE_KEY = 'swing-connect-signup-progress';
+
+export interface Step {
+  number: 1 | 2 | 3;
+  label: string;
+}
+
+export const SIGNUP_STEPS: Step[] = [
+  { number: 1, label: '소셜 로그인' },
+  { number: 2, label: '프로필 정보' },
+  { number: 3, label: '약관 동의' },
+];


### PR DESCRIPTION
## 📝 Summary

Issue #70 - 회원가입 메인 페이지를 생성하고 Step 1-3 컴포넌트를 통합하여 완전한 회원가입 시스템을 구현했습니다.

## ✨ Changes

### Core Integration
- **SignupWizard.tsx**: Firebase/Firestore 통합된 메인 마법사 컴포넌트
  - Step1AccountInfo, Step2ProfileInfo, Step3Terms 통합
  - Firestore 사용자 문서 생성 로직 구현
  - localStorage 기반 진행 상태 저장
  - 네트워크/Firebase 오류 처리

- **app/signup/page.tsx**: Suspense 래퍼가 있는 메인 회원가입 페이지
  - 메타데이터 추가 (title, description)
  - 로딩 폴백 UI
  - Next.js 15 통합

### Component Files
- Step1AccountInfo.tsx: Firebase Auth로 Google 소셜 로그인
- Step2ProfileInfo.tsx: 프로필 정보 입력 폼
- Step3Terms.tsx: 체크박스 로직이 있는 약관 동의
- StepIndicator.tsx: 단계 진행 상태 시각화
- SignupButton.tsx: 재사용 가능한 회원가입 버튼

### Supporting Files
- lib/types/signup.ts: SignupState, SIGNUP_STEPS 상수
- lib/constants/profile.ts: DANCE_LEVELS, REGIONS, DANCE_STYLES, VALIDATION

### Updates
- app/login/page.tsx: 푸터에 회원가입 링크 추가

## 🔧 Firebase Integration

Firestore `users` 컬렉션에 사용자 문서 저장:
```typescript
{
  uid: string,
  email: string,
  displayName: string,
  photoURL: string,
  provider: 'google',
  profile: {
    nickname: string,
    danceLevel: DanceLevel,
    location: string,
    bio: string,
    interests: string[]
  },
  termsAgreed: {
    serviceTerms: boolean,
    privacyPolicy: boolean,
    marketingConsent: boolean,
    agreedAt: timestamp
  },
  createdAt: timestamp,
  lastLoginAt: timestamp
}
```

## ✅ Features Implemented

- ✅ 완전한 3단계 회원가입 플로우
- ✅ Google OAuth 인증
- ✅ 프로필 정보 수집
- ✅ 약관 동의 검증
- ✅ localStorage 진행 상태 저장
- ✅ Firestore 사용자 문서 생성
- ✅ 오류 처리 및 사용자 피드백
- ✅ 반응형 디자인 (모바일 우선)
- ✅ 로그인/회원가입 페이지 간 상호 링크

## 🧪 Testing

- ✅ Lint: No errors (only pre-existing warnings)
- ✅ Build: Success
- ✅ Type-check: No errors in signup code

## 📸 Screenshots

회원가입 플로우:
1. **Step 1**: Google 소셜 로그인
2. **Step 2**: 닉네임, 댄스 레벨, 활동 지역, 자기소개, 관심 댄스 스타일
3. **Step 3**: 서비스 이용약관, 개인정보 처리방침, 마케팅 정보 수신 동의

## 🔗 Related Issues

- Resolves #70
- Depends on #67 (Step1AccountInfo)
- Depends on #68 (Step2ProfileInfo)
- Depends on #69 (Step3Terms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)